### PR TITLE
Fix Matlab binary file reading when machine format does not match

### DIFF
--- a/Utilities/matlabtools/read_spec_field.m
+++ b/Utilities/matlabtools/read_spec_field.m
@@ -103,13 +103,17 @@ catch
    machform     ='a';
    triedallform = 1;
   end
-  
+  if (fid ~= -1)
+   fclose(fid);
+   fid = -1;
+  end
 end
 
 end
 
-
-fclose(fid);
+if (fid ~= -1) 
+    fclose(fid);
+end
 
 
 %return output

--- a/Utilities/matlabtools/read_spec_grid.m
+++ b/Utilities/matlabtools/read_spec_grid.m
@@ -107,13 +107,17 @@ catch
    machform     ='a';
    triedallform = 1;
   end
-  
+  if (fid ~= -1)
+   fclose(fid);
+   fid = -1;
+  end
 end
 
 end
 
-fclose(fid);
-
+if (fid ~= -1) 
+    fclose(fid);
+end
 %return output
 gdata = data;
 

--- a/Utilities/matlabtools/read_spec_iota.m
+++ b/Utilities/matlabtools/read_spec_iota.m
@@ -60,6 +60,7 @@ for i=1:nvol
 	    j=j+nptraj;
             success = 1;
 	    fclose(fid);
+        fid = -1;
         else
         disp(' - File does not exist'); break
         end        
@@ -73,7 +74,11 @@ for i=1:nvol
 	else
 	 machform     ='a';
 	 triedallform = 1;
-	end
+    end
+    if (fid ~= -1)
+     fclose(fid);
+     fid = -1;
+    end
     end
     end
 end

--- a/Utilities/matlabtools/read_spec_poincare.m
+++ b/Utilities/matlabtools/read_spec_poincare.m
@@ -67,11 +67,16 @@ for i=1:nvol
                 end
             end
             fclose(fid);
+            fid = -1;
 	    success=1;
         else
 	 disp(' - File does not exist'); break;
 	end
     catch
+        if (fid ~= -1)
+            fclose(fid);
+            fid = -1;
+        end
         if(triedallform==1)      
          disp(' - Could not read poincare file'); break;
 	end


### PR DESCRIPTION
In "read_spec_xxxx.m":

In the case that the first check of machine format fails (e.g. the binary file uses 'a' while the default is 's'), an exception is thrown and skips the "fclose" statement that closes the opened binary file. The opened binary file will stay in the memory. Even when the namelist is modified and SPEC runs again, the output of read_spec_xxxx subroutines will not be refreshed.

This is fixed by adding a "fclose" statement after the "catch" clause.