### PR TITLE
Fixrestart

### DIFF
--- a/preset.h
+++ b/preset.h
@@ -142,9 +142,9 @@ subroutine preset
 
 !latex \begin{enumerate}
 !latex \item the ``star-like'' poloidal angle constraint weights (only required for toroidal geometry, i.e. \type{Igeometry=3}) are given by
-!latex       \be \type{sweight}_v \equiv \inputvar{upsilon} \times \psi_{v}^w,
+!latex       \be \type{sweight}_v \equiv \inputvar{upsilon} \times (l_v / N_{vol})^w,
 !latex       \ee
-!latex       where $\psi_v \equiv $ \type{tflux(v)} is the normalized toroidal flux enclosed by the $v$-th interface,
+!latex       where $l_v$ is the volume number,
 !latex       and $w \equiv $ \inputvar{wpoloidal}.
 !latex \end{enumerate}
   


### PR DESCRIPTION
The problem with restart in free-boundary is resolved by the fix introduced in this branch.

The code compiles and runs without problem. However, exact comparison with previous control cases is not possible because the angle constraint and thus the angle has changed, hence the Fourier coefficients are going to be different even if the solution is the same. Also, because of the spectrum truncation (Mpol,Ntor) the solution is not expected to be exactly the same anyway.

The code however performs as before for all test cases and the solutions look the same to the eye. Since the definition of sweight is somewhat arbitrary, as was the case before, there is absolutely no reason for any problem arising from this change. 

I am going to merge this branch into master.