### PR TITLE
Changeangle

### DIFF
--- a/global.h
+++ b/global.h
@@ -2116,24 +2116,24 @@ subroutine readin
      
      do ii = 1, mn ; mi = im(ii) ; ni = in(ii) ! loop over harmonics within range;
       if( mm.eq.0 .and. mi.eq.0 .and. nn*Nfp.eq.ni ) then
-       ;iRbc(ii,1:Nvol-1) = RZRZ(1,1:Nvol-1) ! select relevant harmonics;
-       ;iZbs(ii,1:Nvol-1) = RZRZ(2,1:Nvol-1) ! select relevant harmonics;
+       iRbc(ii,1:Nvol-1) = RZRZ(1,1:Nvol-1) ! select relevant harmonics;
+       iZbs(ii,1:Nvol-1) = RZRZ(2,1:Nvol-1) ! select relevant harmonics;
        if( NOTstellsym ) then
-        ;iRbs(ii,1:Nvol-1) = RZRZ(3,1:Nvol-1) ! select relevant harmonics;
-        ;iZbc(ii,1:Nvol-1) = RZRZ(4,1:Nvol-1) ! select relevant harmonics;
+        iRbs(ii,1:Nvol-1) = RZRZ(3,1:Nvol-1) ! select relevant harmonics;
+        iZbc(ii,1:Nvol-1) = RZRZ(4,1:Nvol-1) ! select relevant harmonics;
        else
-        ;iRbs(ii,1:Nvol-1) = zero             ! select relevant harmonics;
-        ;iZbc(ii,1:Nvol-1) = zero             ! select relevant harmonics;
+        iRbs(ii,1:Nvol-1) = zero             ! select relevant harmonics;
+        iZbc(ii,1:Nvol-1) = zero             ! select relevant harmonics;
        endif
       elseif( mm.eq.mi .and. nn*Nfp.eq.jj*ni ) then
-       ;iRbc(ii,1:Nvol-1) = RZRZ(1,1:Nvol-1) ! select relevant harmonics;
-       ;iZbs(ii,1:Nvol-1) = jj*RZRZ(2,1:Nvol-1) ! select relevant harmonics;
+       iRbc(ii,1:Nvol-1) = RZRZ(1,1:Nvol-1) ! select relevant harmonics;
+       iZbs(ii,1:Nvol-1) = jj*RZRZ(2,1:Nvol-1) ! select relevant harmonics;
        if( NOTstellsym ) then
-        ;iRbs(ii,1:Nvol-1) = jj*RZRZ(3,1:Nvol-1) ! select relevant harmonics;
-        ;iZbc(ii,1:Nvol-1) = RZRZ(4,1:Nvol-1) ! select relevant harmonics;
+        iRbs(ii,1:Nvol-1) = jj*RZRZ(3,1:Nvol-1) ! select relevant harmonics;
+        iZbc(ii,1:Nvol-1) = RZRZ(4,1:Nvol-1) ! select relevant harmonics;
        else
-        ;iRbs(ii,1:Nvol-1) = zero             ! select relevant harmonics;
-        ;iZbc(ii,1:Nvol-1) = zero             ! select relevant harmonics;
+        iRbs(ii,1:Nvol-1) = zero             ! select relevant harmonics;
+        iZbc(ii,1:Nvol-1) = zero             ! select relevant harmonics;
        endif
       endif
      enddo ! end of do ii;


### PR DESCRIPTION
I have modified the routine global.h in order to make SPEC deal with cases in which an initial guess is given in the input file for the inner surfaces (Linitialize=0) and such that the poloidal angle corresponding to the provided geometric representation has opposite sign to the SPEC poloidal angle. Namely, the Fourier coefficients for R,Z are transformed in such a way that the poloidal angle has the "correct" sign. This was already being done in SPEC for the boundary but not for internal surfaces.

This modification has enabled to run SPEC for a CFQS equilibrium in which initial guess had this property.

Please check that the branch compiles and runs for some test cases of your choice.

Then we can merge this into master.