### PR TITLE
print the number of OMP threads on screen

### DIFF
--- a/xspech.f90
+++ b/xspech.f90
@@ -131,8 +131,13 @@ program xspech
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
   
   if( myid.eq.0 ) then
+#ifdef OPENMP
+  nthreads = omp_get_max_threads()
+#else
+  nthreads = 1
+#endif
    write(ounit,'("xspech : ", 10x ," : ")')
-   write(ounit,'("xspech : ",f10.2," : begin execution ; ncpu=",i3," ; calling global:readin ;")') cpus-cpus, ncpu
+   write(ounit,'("xspech : ",f10.2," : begin execution ; ncpu=",i3," ; omp_threads=",i3,"; calling global:readin ;")') cpus-cpus, ncpu, nthreads
   endif
   
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!


### PR DESCRIPTION
This small patch will print the number of OpenMP threads on the screen output of SPEC, right next to "ncpus" which stands for the number of MPI jobs. The total number of CPUs being used will be the two multiplied together.