### PR TITLE
cmake ninja and hdf5-static added to Docker image

### DIFF
--- a/ci/Dockerfile.centos7
+++ b/ci/Dockerfile.centos7
@@ -3,11 +3,12 @@ FROM centos:7
 #setup the base sysem
 RUN yum group install "Development Tools" -y
 RUN yum -y install epel-release
-RUN yum install gcc-gfortran openmpi openmpi-devel hdf5 hdf5-devel hdf5-static -y
+RUN yum install gcc-gfortran openmpi openmpi-devel hdf5 hdf5-devel -y
 RUN yum install fftw3 fftw3-devel openblas openblas-devel -y
 RUN yum install blas blas-devel lapack lapack-devel -y
 RUN yum install -y python3 python3-devel
-RUN pip3 install h5py matplotlib f90nml cmake ninja
+RUN yum install -y cmake ninja-build
+RUN pip3 install h5py matplotlib f90nml
 
 # direct the existing makefile to the system install location
 ENV FFTW_HOME=/usr


### PR DESCRIPTION
I am adding ninja and cmake (installed via pip) and hdf5-static to the Docker image to prevent issues with cmake build.

@smiet, could you please replace the docker image with the new image with above mentioned packages installed and let me know?