### PR TITLE
Tweaks to python wrapper to allow hdf5 files to be written if desired

### DIFF
--- a/Utilities/python_wrapper/Makefile
+++ b/Utilities/python_wrapper/Makefile
@@ -64,7 +64,7 @@ LIB_NAME = lib$(PYTHON_MODN).a
 #=======================================================================
 
 # names (without suffix), f90 sources
-TMP_FILES := ${BASEFILES} ${SPECFILES} xspech
+TMP_FILES := ${ALLSPEC} xspech
 LIBSRC_WRAP_SOURCES := $(TMP_FILES)
 
 # file names

--- a/Utilities/python_wrapper/example.py
+++ b/Utilities/python_wrapper/example.py
@@ -19,6 +19,7 @@ fun.read()
 fun.inputlist.nppts = 0
 # main execution
 fun.run()
+#fun.run(save_output=True)
 
 # target volume
 target = 30.0

--- a/Utilities/python_wrapper/kind_map
+++ b/Utilities/python_wrapper/kind_map
@@ -13,5 +13,8 @@
  'integer' : {   '' : 'long_long',
                 '4' : 'int',
 	            '8' : 'long_long',
-	           'dp' : 'long_long' }
+	           'dp' : 'long_long',
+		   'hid_t' : 'long_long',
+		   'hsize_t' : 'long_long',
+		   'size_t' : 'long_long'}
 }


### PR DESCRIPTION
Previously, the sphdf5 module was not accessible in the python module because sphdf5 was not included in the python wrapper Makefile in
~~~
TMP_FILES := ${BASEFILES} ${SPECFILES} xspech
~~~
When sphdf5 was added here by using ALLSPEC, f90wrap wanted `hid_t`, `hsize_t`, and `size_t` to be added to kind_map.  Finally, core.py was extended a bit to show how the output files can be written if desired.