### PR TITLE
Tweaks needed to get SPEC python wrapper working with simsopt

### DIFF
--- a/macros
+++ b/macros
@@ -91,6 +91,7 @@ m4_define(NALLOCATE,{! macro expansion of nallocate;
 
 #endif
 
+   if( allocated( $1 ) ) deallocate( $1 )
    allocate($1$2,stat=astat)
 
 #ifdef DEBUG

--- a/preset.f90
+++ b/preset.f90
@@ -353,8 +353,8 @@ subroutine preset
 
     enddo ! end of do;
 
-    ! have been allocated in read_inputlists_from_file
-    deallocate(mmRZRZ, nnRZRZ, allRZRZ)
+    ! Typically these arrays have been allocated in read_inputlists_from_file
+    if(allocated(mmRZRZ)) deallocate(mmRZRZ, nnRZRZ, allRZRZ)
 
    end select ! end select case( Linitialize );
 


### PR DESCRIPTION
Just added a couple checks before allocating/deallocating.