### PR TITLE
Hotfix wrapper seg fault

### DIFF
--- a/global.f90
+++ b/global.f90
@@ -993,6 +993,8 @@ subroutine read_inputlists_from_file()
      FATAL(inplst, seek_status.ne.0, failed to seek to end of input namelists )
 
      ! now allocate arrays and read...
+     ! Need to free memory, in case preset() called multiple times via python wrappers
+     if(allocated(mmRZRZ)) deallocate(mmRZRZ, nnRZRZ, allRZRZ)
      allocate(mmRZRZ(1:num_modes), nnRZRZ(1:num_modes), allRZRZ(1:4,1:Nvol,1:num_modes))
 
      do idx_mode = 1, num_modes

--- a/preset.f90
+++ b/preset.f90
@@ -353,9 +353,6 @@ subroutine preset
 
     enddo ! end of do;
 
-    ! Typically these arrays have been allocated in read_inputlists_from_file
-    if(allocated(mmRZRZ)) deallocate(mmRZRZ, nnRZRZ, allRZRZ)
-
    end select ! end select case( Linitialize );
 
    if( Igeometry.eq.3 ) then

--- a/xspech.f90
+++ b/xspech.f90
@@ -934,18 +934,13 @@ subroutine ending
 
   use cputiming
 
-  use allglobal, only : myid, cpus, mn, MPI_COMM_SPEC, ext, mmRZRZ, nnRZRZ, allRZRZ
-
+  use allglobal, only : myid, cpus, mn, MPI_COMM_SPEC, ext
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
   LOCALS
 
   REAL      :: Ttotal, dcpu, ecpu
   CHARACTER :: date*8, time*10
-
-! Need to deallocate if not done before.
-! This are the only variables not allocated in preset()...
-  if(allocated(mmRZRZ)) deallocate(mmRZRZ, nnRZRZ, allRZRZ)
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 

--- a/xspech.f90
+++ b/xspech.f90
@@ -934,7 +934,7 @@ subroutine ending
 
   use cputiming
 
-  use allglobal, only : myid, cpus, mn, MPI_COMM_SPEC, ext
+  use allglobal, only : myid, cpus, mn, MPI_COMM_SPEC, ext, mmRZRZ, nnRZRZ, allRZRZ
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
@@ -942,6 +942,10 @@ subroutine ending
 
   REAL      :: Ttotal, dcpu, ecpu
   CHARACTER :: date*8, time*10
+
+! Need to deallocate if not done before.
+! This are the only variables not allocated in preset()...
+  if(allocated(mmRZRZ)) deallocate(mmRZRZ, nnRZRZ, allRZRZ)
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 


### PR DESCRIPTION
Hello!

This is a quick fix to a problem when SPEC is ran via the python wrappers (for example from simsopt) and with `Lfindzero=0`. This lead to a segmentation fault in some cases. Please see issue hiddenSymmetries/simsopt#135 for more details.

