### PR TITLE
add cpuo=0 to avoid using before initialization

### DIFF
--- a/src/macros
+++ b/src/macros
@@ -31,7 +31,7 @@ m4_define(LOCALS,{! macro expansion of locals;
   use mpi
   implicit none
   INTEGER   :: ierr, astat, ios, nthreads, ithread
-  REAL      :: cput, cpui, cpuo ! cpu time; cpu initial; cpu old; 31 Jan 13;
+  REAL      :: cput, cpui, cpuo=0 ! cpu time; cpu initial; cpu old; 31 Jan 13;
 
   ! macro expansion of locals; end;})m4_dnl ; can put comments here;
 


### PR DESCRIPTION
Just found a small bug. In some cases, `cpuo` is used before initialization. This will cause errors if the compiler has no `init-zero` turned on (like in `dspec`).

For example, the following one is copied from `dfp200_m.F90`.

```Fortran
 real(8)      :: cput, cpui, cpuo ! cpu time; cpu initial; cpu old; 31 Jan 13;

  ! macro expansion of locals; end;
! ------
  TYPE(MatrixLU), intent(inout) :: oBI
  integer, intent(in)    :: vvol, NN

  integer             :: IA, MM, LDA, Lwork, ll
  integer             :: idgetrf, idgetri
  real(8)                :: lastcpu
  real(8), allocatable   :: work(:)

!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-

  lastcpu = MPI_WTIME()

  ll = Lrad(vvol)

  ! Evaluate dMa, dMD
  dBdX%L = .false.

  Lsavedguvij = .false.

 ! macro expansion of wcall;
! call _2 with arguments _3 from within _1 and write wall time needed for call to screen

   cput = MPI_WTIME()
   Tdfp200 = Tdfp200 + ( cput-cpuo )
```

```
forrtl: severe (194): Run-Time Check Failure. The variable 'get_lu_beltrami_matrices_$CPUO' is being used in 'dfp200_m.F90(2016,4)' without being defined
Image              PC                Routine            Line        Source
dspec              0000000000DB5003  get_lu_beltrami_m        2016  dfp200_m.F90
dspec              0000000000D899BB  dfp200_                  1175  dfp200_m.F90
dspec              0000000000E7B452  dforce_                  1048  dforce_m.F90
dspec              0000000000EE2797  fcn2_                    1745  newton_m.F90
dspec              000000000044928C  hybrj_                    672  minpack.f
dspec              0000000000ECA064  newton_                   548  newton_m.F90
dspec              00000000010135BA  spec_                     631  xspech_m.F90
dspec              000000000100CC2F  xspech_                   192  xspech_m.F90
dspec              000000000100BD05  MAIN__                     22  xspech_m.F90
dspec              000000000040E4A2  Unknown               Unknown  Unknown
libc-2.28.so       0000146F0C033493  __libc_start_main     Unknown  Unknown
dspec              000000000040E3AE  Unknown               Unknown  Unknown
```

Alternatively, we can add the line `cpuo=zero` before using it. But I am not quite sure if this is the only place.