### PR TITLE
The f90wrap generated module name is changed from spec to spec_f90wrapped 

### DIFF
--- a/Utilities/python_wrapper/CMakeLists.txt
+++ b/Utilities/python_wrapper/CMakeLists.txt
@@ -79,7 +79,7 @@ set(f90wrap_output_files ${CMAKE_CURRENT_BINARY_DIR}/f90wrap_global_m_fpp.f90
 
 set(kind_map_file ${CMAKE_CURRENT_SOURCE_DIR}/kind_map)
 set(python_mod_name spec)
-set(python_mod_file ${CMAKE_CURRENT_BINARY_DIR}/${python_mod_name}.py)
+set(python_mod_file ${CMAKE_CURRENT_BINARY_DIR}/${python_mod_name}_f90wrapped.py)
 
 add_custom_target(preprocessing ALL
   DEPENDS ${fpp_files}

--- a/Utilities/python_wrapper/CMakeLists.txt
+++ b/Utilities/python_wrapper/CMakeLists.txt
@@ -78,8 +78,8 @@ set(f90wrap_output_files ${CMAKE_CURRENT_BINARY_DIR}/f90wrap_global_m_fpp.f90
 )
 
 set(kind_map_file ${CMAKE_CURRENT_SOURCE_DIR}/kind_map)
-set(python_mod_name spec)
-set(python_mod_file ${CMAKE_CURRENT_BINARY_DIR}/${python_mod_name}_f90wrapped.py)
+set(python_mod_name spec_f90wrapped)
+set(python_mod_file ${CMAKE_CURRENT_BINARY_DIR}/${python_mod_name}.py)
 
 add_custom_target(preprocessing ALL
   DEPENDS ${fpp_files}

--- a/Utilities/python_wrapper/spec/core.py
+++ b/Utilities/python_wrapper/spec/core.py
@@ -8,7 +8,7 @@ import sys
 import os
 import logging
 from mpi4py import MPI
-import spec.spec as spec
+import spec.spec_f90wrapped as spec
 
 logger = logging.getLogger("[{}]".format(MPI.COMM_WORLD.Get_rank()) + __name__)
 


### PR DESCRIPTION
To prevent confusion with multiple files with the same name, f90wrapper generated module is renamed to spec_f90wrapped. Changes are made only to Cmake framework. Makefile is not touched.