### PR TITLE
Add options to generate a template input file

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -1129,6 +1129,37 @@ end subroutine ! read_inputlists_from_file
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
+!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+
+subroutine write_spec_namelist()
+  ! write all the namelists to example.sp
+  use constants
+  use fileunits
+  use inputlist
+
+  LOCALS
+
+  LOGICAL :: exist
+  CHARACTER(LEN=100), PARAMETER :: example = 'example.sp'
+
+  if( myid == 0 ) then
+     inquire(file=trim(example), EXIST=exist) ! inquire if inputfile existed;
+     FATAL( global, exist, example input file example.sp already existed )
+     open(iunit, file=trim(example), status='unknown', action='write')
+     write(iunit, physicslist)
+     write(iunit, numericlist)
+     write(iunit, locallist)
+     write(iunit, globallist)
+     write(iunit, diagnosticslist)
+     write(iunit, screenlist)
+     close(iunit)
+  endif
+
+  return
+end subroutine
+
+!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+
 subroutine check_inputs()
 
    use numerical

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -204,7 +204,7 @@ subroutine read_command_args
 
   use fileunits, only: ounit
   use inputlist, only: Wreadin
-  use allglobal, only: cpus, myid, ext, MPI_COMM_SPEC
+  use allglobal, only: cpus, myid, ext, MPI_COMM_SPEC, write_spec_namelist
 
   LOCALS
 
@@ -233,7 +233,7 @@ subroutine read_command_args
         call MPI_ABORT( MPI_COMM_SPEC, 0, ierr )
     case ("-i", "--init")
         write(ounit,'("rdcmdl : ", 10x ," : write a template input file in example.sp")')
-        ! call write_spec_namelist()
+        call write_spec_namelist()
         call MPI_ABORT( MPI_COMM_SPEC, 0, ierr )
     case default
         extlen = len_trim(arg)

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -209,7 +209,7 @@ subroutine read_command_args
   LOCALS
 
   LOGICAL              :: Lspexist
-  INTEGER              :: iargc, iarg, numargs, extlen, sppos, ierr
+  INTEGER              :: iargc, iarg, numargs, extlen, sppos
 
   CHARACTER(len=100)   :: arg
 
@@ -219,28 +219,30 @@ subroutine read_command_args
 
     ! first command-line argument is likely ext or ext.sp
     call getarg( 1, arg )
-    extlen = len_trim(arg)
-    sppos = index(arg, ".sp", .true.) ! search for ".sp" from the back of ext
-    if (sppos.eq.extlen-2) then       ! check if ext ends with ".sp"
-      arg = arg(1:extlen-3)           ! if this is the case, remove ".sp" from end of ext
-    endif
-    ext = trim(arg)
 
     write(ounit,'("rdcmdl : ", 10x ," : ")')
-    select case (ext)
+    select case (trim(arg))
     case ("", "-h", "--help")
         write(ounit,'("rdcmdl : ", 10x ," : file extension must be given as first command line argument ;")')
         write(ounit,'("rdcmdl : ", 10x ," : Usage: <mpiexec> xspec input_file <arguments>")')
         write(ounit,'("rdcmdl : ", 10x ," : Other options:")')
         write(ounit,'("rdcmdl : ", 10x ," :     -h / --help :  print help information.")')
-        write(ounit,'("rdcmdl : ", 10x ," :     -i / --init :  generate an input template.")')
+        write(ounit,'("rdcmdl : ", 10x ," :     -i / --init :  generate a template input file.")')
         write(ounit,'("rdcmdl : ", 10x ," : Additional arguments:")')
         write(ounit,'("rdcmdl : ", 10x ," :     -readin : print debugging information during reading inputs")')
         call MPI_ABORT( MPI_COMM_SPEC, 0, ierr )
     case ("-i", "--init")
+        write(ounit,'("rdcmdl : ", 10x ," : write a template input file in example.sp")')
         ! call write_spec_namelist()
         call MPI_ABORT( MPI_COMM_SPEC, 0, ierr )
     case default
+        extlen = len_trim(arg)
+        sppos = index(arg, ".sp", .true.) ! search for ".sp" from the back of ext
+        if (sppos.eq.extlen-2) then       ! check if ext ends with ".sp"
+            arg = arg(1:extlen-3)         ! if this is the case, remove ".sp" from end of ext
+        endif
+        ext = trim(arg)
+
         write(ounit,'("rdcmdl : ", 10x ," : ")')
         write(ounit,'("rdcmdl : ",f10.2," : ext = ",a100)') cput-cpus, ext
     end select


### PR DESCRIPTION
I have implemented the feasibility to write a template input file, as well as new help information.

Now users can use `xspec -h` to print help info and use `xspec -i` to generate a template input file which will be always synced to the namelists.

The only drawback is that it writes the maximum length of all arrays. So one probably need to revise the dimensionality.

The help information
```
rdcmdl :            : Usage: <mpiexec> xspec input_file <arguments>
rdcmdl :            : Other options:
rdcmdl :            :     -h / --help :  print help information.
rdcmdl :            :     -i / --init :  generate a template input file.
rdcmdl :            : Additional arguments:
rdcmdl :            :     -readin : print debugging information during reading inputs
```

Part of the `example.sp`:
```
 OITA= 257*0.0000000000000000       ,
 MUPFTOL=  1.0000000000000000E-014,
 MUPFITS=8          ,
 RPOL=  1.0000000000000000     ,
 RTOR=  1.0000000000000000     ,
 LREFLECT=0          ,
 RAC= 129*0.0000000000000000       ,
 ZAS= 129*0.0000000000000000       ,
 RAS= 129*0.0000000000000000       ,
 ZAC= 129*0.0000000000000000       ,
 RBC= 66049*0.0000000000000000       ,
 ZBS= 66049*0.0000000000000000       ,
 RBS= 66049*0.0000000000000000       ,
 ZBC= 66049*0.0000000000000000       ,
```