### PR TITLE
Fix integer type in the python wrapper

### DIFF
--- a/Utilities/python_wrapper/Makefile
+++ b/Utilities/python_wrapper/Makefile
@@ -124,4 +124,4 @@ compile_test:
 	@echo "LINKS = ${LINKS}"
 
 test:
-	@${PYTHON} -c "from spec import spec; print('SPEC version: {:}'.format(spec.constants.version))"
+	@${PYTHON} -c "import spec.spec_f90wrapped as spec; print('SPEC version: {:}'.format(spec.constants.version))"

--- a/Utilities/python_wrapper/kind_map
+++ b/Utilities/python_wrapper/kind_map
@@ -10,11 +10,11 @@
  	           '16' : 'complex_long_double',
  	           'dp' : 'complex_double',
              'c_double_complex': 'complex_double'},
- 'integer' : {   '' : 'long_long',
+ 'integer' : {   '' : 'int',
                 '4' : 'int',
 	            '8' : 'long_long',
 	           'dp' : 'long_long',
-		   'hid_t' : 'long_long',
-		   'hsize_t' : 'long_long',
+		   'hid_t'  : 'long_long',
+		   'hsize_t': 'long_long',
 		   'size_t' : 'long_long'}
 }


### PR DESCRIPTION
1. Fix integer type in the python wrapper
2. Update make test option