### PR TITLE
Update spec_namelist.py

### DIFF
--- a/Utilities/pythontools/py_spec/input/spec_namelist.py
+++ b/Utilities/pythontools/py_spec/input/spec_namelist.py
@@ -596,7 +596,7 @@ class SPECNamelist(Namelist):
 
             # ignore empty lines
             if len(line_split) == 0:
-                break
+                continue
 
             # check if this line meet our expectation
             valid_line = True


### PR DESCRIPTION
When reading interface guess, `continue` should be used instead of `break` if the empty line should be ignored.