### PR TITLE
Ml/scipy requirement

### DIFF
--- a/.github/workflows/py_spec.yml
+++ b/.github/workflows/py_spec.yml
@@ -19,7 +19,7 @@ jobs:
       working-directory: ${{ env.PY_SPEC_DIR }}
       run: |
         pip3 install -r requirements.txt
-        pip3 install setuptools wheel twine scipy 
+        pip3 install setuptools wheel twine
 
     - name: Build py_spec
       working-directory: ${{ env.PY_SPEC_DIR }}

--- a/Utilities/pythontools/requirements.txt
+++ b/Utilities/pythontools/requirements.txt
@@ -2,4 +2,5 @@ h5py
 matplotlib
 f90nml
 numpy
+scipy
 coilpy


### PR DESCRIPTION
The simsopt CI has just started failing at the step when py_spec is `pip install`ed, with an error `ModuleNotFoundError: No module named 'scipy'`. I think this is because SPEC PR #183 added an import from scipy (in `Utilities/pythontools/py_spec/output/_processing.py`) without adding scipy to `requirements.txt`. This is addressed in this PR.