### PR TITLE
fix plot_iota

### DIFF
--- a/Utilities/pythontools/py_spec/output/_plot_iota.py
+++ b/Utilities/pythontools/py_spec/output/_plot_iota.py
@@ -29,7 +29,7 @@ def plot_iota(self, xaxis="R", yaxis="i", ax=None, **kwargs):
         xlabel = r"s"
     elif xaxis == "R":
         xdata = self.poincare.R[:, 0, 0]
-        ydata = self.transform.fiota[1, :]
+        ydata = self.transform.fiota[1, self.poincare.success == 1]
         xlabel = r"R"
     else:
         raise ValueError("xaxis should be one of ['R', 's'].")


### PR DESCRIPTION
When trying to plot the iota profile, the `xdata` is R for all  Poincare trajectories, but the `ydata`  removes unsuccessful Poincare trajectories, so the length of the `xdata` and `ydata` may not be equal.