### PR TITLE
solved bug in get_average_beta

### DIFF
--- a/Utilities/pythontools/py_spec/__init__.py
+++ b/Utilities/pythontools/py_spec/__init__.py
@@ -1,5 +1,5 @@
 # import of all SPEC-related python scripts.
-__version__ = "3.3.0"
+__version__ = "3.3.2"
 
 from .ci import test
 from .input.spec_namelist import SPECNamelist

--- a/Utilities/pythontools/py_spec/output/_processing.py
+++ b/Utilities/pythontools/py_spec/output/_processing.py
@@ -547,7 +547,7 @@ def get_average_beta(self, ns=64, nt=64, nz=64):
         
         return betavol / vols
     else:
-        for ivol in range(0,nvol-1):
+        for ivol in range(0,nvol):
             if ivol==0: sarr=np.linspace(-0.999,1, ns)
             if ivol!=0: sarr=np.linspace(-1,    1, ns)
 

--- a/Utilities/pythontools/requirements.txt
+++ b/Utilities/pythontools/requirements.txt
@@ -2,5 +2,8 @@ h5py
 matplotlib
 f90nml
 numpy
-scipy
+
+# Version 1.7.0 or higher is required - otherwise scipy.integrate.simpson does not exist
+scipy>=1.7.0
+
 coilpy


### PR DESCRIPTION
Two small fixes - especially in py_spec, there was a mistake in the routine SPECout.get_average_beta().