### PR TITLE
removed .ci from py_spec.__init__

### DIFF
--- a/Utilities/pythontools/py_spec/__init__.py
+++ b/Utilities/pythontools/py_spec/__init__.py
@@ -1,6 +1,6 @@
 # import of all SPEC-related python scripts.
 __version__ = "3.3.2"
 
-from .ci import test
+#from .ci import test
 from .input.spec_namelist import SPECNamelist
 from .output.spec import SPECout


### PR DESCRIPTION
Quick fix to issue #194.

Maybe not the best fix but at least we can install and use py_spec...