### PR TITLE
 replace deprecated np.fload with np.float64 https://numpy.org/devdoc…

### DIFF
--- a/Utilities/pythontools/py_spec/input/spec_namelist.py
+++ b/Utilities/pythontools/py_spec/input/spec_namelist.py
@@ -637,7 +637,7 @@ class SPECNamelist(Namelist):
         for key in self.boundary_keys:
             if key.lower() not in self["physicslist"].keys():
                 self["physicslist"][key] = np.zeros(
-                    [self._Mpol, self._Ntor * 2 + 1], dtype=np.float
+                    [self._Mpol, self._Ntor * 2 + 1], dtype=np.float64
                 ).tolist()
                 self["physicslist"].start_index[key.lower()] = [-self._Ntor, 0]
             else:
@@ -651,7 +651,7 @@ class SPECNamelist(Namelist):
         for key in self.axis_keys:
             if key.lower() not in self["physicslist"].keys():
                 self["physicslist"][key] = np.zeros(
-                    [self._Ntor + 1], dtype=np.float
+                    [self._Ntor + 1], dtype=np.float64
                 ).tolist()
                 self["physicslist"].start_index[key.lower()] = [0]
             else:


### PR DESCRIPTION
np.float deprecated in numpy 1.20. 
Comparison, and error usually skipped because arrays are given in input file, and are floats.
Two stale occurrences fixed, grep shows no other occurrences in python codebase of "np.float"

https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations