### PR TITLE
fix bug in writing .sp.end, when Lconstraint.\neq.3 and Nvol=1 Isurf …

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -1654,7 +1654,7 @@ subroutine wrtend
   write(iunit,'(" adiabatic   = ",257es23.15)') adiabatic(1:Mvol)
   write(iunit,'(" mu          = ",257es23.15)') mu(1:Mvol)
   write(iunit,'(" Ivolume     = ",257es23.15)') Ivolume(1:Mvol)
-  write(iunit,'(" Isurf       = ",257es23.15)') Isurf(1:Mvol-1)
+  write(iunit,'(" Isurf       = ",257es23.15)') Isurf(1:Mvol-1), 0.0
   write(iunit,'(" Lconstraint = ",i9        )') Lconstraint
   write(iunit,'(" pl          = ",257i23    )') pl(0:Mvol)
   write(iunit,'(" ql          = ",257i23    )') ql(0:Mvol)


### PR DESCRIPTION
This is a quick fix of a bug in writing .sp.end, which appears when Lconstraint not equal to 3, and Nvol=1; in that case, Isurf was printed in the .sp.end as 'void' and thus one could not restart run from that file. 

BEFORE: running e.g. the testcase G3V01L0Fi.001.sp, copying the G3V01L0Fi.001.sp.end into test.sp and rerunning, would give an error and crash.
NOW: no error, it works fine.

we should merge to master