### PR TITLE
Bnserr to hdf5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ d['cmake_args'].append("-DCMAKE_C_FLAGS=-I"+numpy.get_include())
 
 setup(
     name="spec",
-    version="0.0.1",
+    version="0.0.2",
     #license="MIT",
     packages=['spec'],
     package_dir={'': 'Utilities/python_wrapper'},

--- a/src/global.f90
+++ b/src/global.f90
@@ -66,7 +66,7 @@ module constants
   REAL, parameter :: mu0        =   2.0E-07 * pi2       !< \f$4\pi\cdot10^{-7}\f$
   REAL, parameter :: goldenmean =   1.618033988749895   !< golden mean = \f$( 1 + \sqrt 5 ) / 2\f$ ;
 
-  REAL, parameter :: version    =   3.21  !< version of SPEC
+  REAL, parameter :: version    =   3.22  !< version of SPEC
 
 end module constants
 

--- a/src/global.f90
+++ b/src/global.f90
@@ -250,6 +250,7 @@ module allglobal
 
   REAL                 :: ForceErr !< total force-imbalance
   REAL                 :: Energy   !< MHD energy
+  REAL                 :: BnsErr   !< (in freeboundary) error in self-consistency of field on plasma boundary (Picard iteration)
 
   REAL   , allocatable :: IPDt(:), IPDtDpf(:,:)  !< Toroidal pressure-driven current
 

--- a/src/sphdf5.f90
+++ b/src/sphdf5.f90
@@ -982,7 +982,7 @@ subroutine hdfint
   use fileunits, only : ounit
   use inputlist
   use allglobal, only : ncpu, cpus, &
-                        Mvol, ForceErr, &
+                        Mvol, ForceErr, BnsErr,&
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, &
                         mns, ims, ins, &
                         dRbc, dZbs, dRbs, dZbc, &
@@ -1042,8 +1042,8 @@ subroutine hdfint
   HWRITERA( grpOutput, mn, (Mvol+1), Rbs, iRbs(1:mn,0:Mvol) )
 !latex \type{iZbc(1:mn,0:Mvol)}      & real    & \pb{Fourier harmonics, $Z_{m,n}$, of interfaces} \\
   HWRITERA( grpOutput, mn, (Mvol+1), Zbc, iZbc(1:mn,0:Mvol) )
-!l tex \type{forcetol}               & real    & \pb{force-balance error across interfaces} \\
-!  HWRITERV( grpOutput, 1, forcetol, (/ forcetol /)) ! already in /input/global
+!latex \type{BnsErr}                 & real    & \pb{error in self-consistency of field on plasma boundary (in freeboundary)} \\
+  HWRITERV( grpOutput, 1, BnsErr, (/ BnsErr /)) ! already in /input/global
 !latex \type{ForceErr}               & real    & \pb{force-balance error across interfaces} \\
   HWRITERV( grpOutput,  1, ForceErr, (/ ForceErr /))
 !latex \type{Ivolume}                & real    & \pb{Volume current at output (parallel, externally induced)}

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -308,7 +308,7 @@ subroutine spec
                         Lcoordinatesingularity, Lplasmaregion, Lvacuumregion, &
                         dtflux, dpflux, &
                         ImagneticOK, &
-                        ForceErr, &
+                        ForceErr, BnsErr,&
                         efmn, ofmn, cfmn, sfmn, &
                         iBns, iBnc, iVns, iVnc, &
                         Ate, Aze, Ato, Azo, & ! only required for debugging; 09 Mar 17;
@@ -326,7 +326,7 @@ subroutine spec
   LOGICAL              :: LComputeDerivatives, LContinueFreeboundaryIterations, exist, LupdateBn, LComputeAxis
   INTEGER              :: imn, lmn, lNfp, lim, lin, ii, ideriv, stat
   INTEGER              :: vvol, ifail, wflag, iflag, vflag
-  REAL                 :: rflag, lastcpu, bnserr, lRwc, lRws, lZwc, lZws, lItor, lGpol, lgBc, lgBs
+  REAL                 :: rflag, lastcpu, lRwc, lRws, lZwc, lZws, lItor, lGpol, lgBc, lgBs
   REAL,    allocatable :: position(:), gradient(:)
   CHARACTER            :: pack
   INTEGER              :: Lfindzero_old, mfreeits_old


### PR DESCRIPTION
The output of a freeboundary run should contain the bnserr. 

Added bnserr as a global variable (was: local variable in xspec), and write it to the output group of the hdf5 file. 

Updated version number of spec to 3.22 and of the python wrapper to 0.0.2 so user can check if this is available (f.ex. in simsopt). 

Just asking for a sanity check, should not affect any existing use of SPEC. 

