### PR TITLE
Numpy2 fix

### DIFF
--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -6,26 +6,25 @@ jobs:
     name: python_wrapper build
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Python3 should be pre-installed on 'ubuntu-latest'
     - name: Python version info
       run: |
-        python3 --version
-        pip3 --version
+        python --version
+        pip --version
 
     - name: Install dependencies
       run: |
         sudo apt-get update
         sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev cmake ninja-build
-        pip3 install --user numpy f90nml scikit-build scipy
-        pip3 install --user git+https://github.com/zhucaoxiang/f90wrap@main_off
+        pip install  numpy f90nml scikit-build scipy
+        pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
 
     - name: Build python_wrapper
       run: |
-        python3 setup.py bdist_wheel
-        pip3 install --user dist/*.whl
+        pip install .
         
     - name: Test if installation is ok
       run: |
-        python3 -c "import spec; print('success')"
+        python -c "import spec; print('success')"

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev  libopenblas-dev cmake ninja-build
-        pip install  numpy f90nml scikit-build scipy meson python-meson
+        pip install  numpy f90nml scikit-build scipy meson meson-python
         pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
 
     - name: Build python_wrapper

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev  libopenblas-dev cmake ninja-build meson
-        pip install  numpy f90nml scikit-build scipy
+        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev  libopenblas-dev cmake ninja-build
+        pip install  numpy f90nml scikit-build scipy meson python-meson
         pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
 
     - name: Build python_wrapper

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev cmake ninja-build meson
+        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev  libopenblas-dev cmake ninja-build meson
         pip install  numpy f90nml scikit-build scipy
         pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
 

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -19,7 +19,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev cmake ninja-build
         pip3 install --user numpy f90nml scikit-build scipy
-        pip3 install --user git+https://github.com/zhucaoxiang/f90wrap
+        pip3 install --user git+https://github.com/zhucaoxiang/f90wrap@main_off
 
     - name: Build python_wrapper
       run: |

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev cmake ninja-build
+        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev cmake ninja-build meson
         pip install  numpy f90nml scikit-build scipy
         pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
 

--- a/Utilities/pythontools/py_spec/__init__.py
+++ b/Utilities/pythontools/py_spec/__init__.py
@@ -1,5 +1,5 @@
 # import of all SPEC-related python scripts.
-__version__ = "3.3.3"
+__version__ = "3.3.4"
 
 from .ci import test
 from .input.spec_namelist import SPECNamelist

--- a/Utilities/pythontools/requirements.txt
+++ b/Utilities/pythontools/requirements.txt
@@ -1,7 +1,6 @@
 h5py
 matplotlib
 f90nml
-numpy>2.0
 
 # Version 1.7.0 or higher is required - otherwise scipy.integrate.simpson does not exist
 scipy>=1.7.0

--- a/Utilities/pythontools/requirements.txt
+++ b/Utilities/pythontools/requirements.txt
@@ -1,7 +1,7 @@
 h5py
 matplotlib
 f90nml
-numpy
+numpy>2.0
 
 # Version 1.7.0 or higher is required - otherwise scipy.integrate.simpson does not exist
 scipy>=1.7.0

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -7,6 +7,8 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="py_spec",
     version=__version__,
+    setup_requires=["numpy>=2.0"],
+    install_requires=["numpy>=1.23.5"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     name="py_spec",
     version=__version__,
     setup_requires=["numpy>=2.0"],
-    install_requires=["numpy>=1.23.5"],
+    install_requires=["numpy>=1.21.1"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ d['cmake_args'].append("-DCMAKE_C_FLAGS=-I"+numpy.get_include())
 
 setup(
     name="spec",
-    version="0.0.2",
+    version="0.0.3",
     #license="MIT",
     packages=['spec'],
     package_dir={'': 'Utilities/python_wrapper'},

--- a/src/global.f90
+++ b/src/global.f90
@@ -66,7 +66,7 @@ module constants
   REAL, parameter :: mu0        =   2.0E-07 * pi2       !< \f$4\pi\cdot10^{-7}\f$
   REAL, parameter :: goldenmean =   1.618033988749895   !< golden mean = \f$( 1 + \sqrt 5 ) / 2\f$ ;
 
-  REAL, parameter :: version    =   3.22  !< version of SPEC
+  REAL, parameter :: version    =   3.23  !< version of SPEC
 
 end module constants
 

--- a/src/hesian.f90
+++ b/src/hesian.f90
@@ -1,7 +1,7 @@
 !> \file
-!> \brief Computes eigenvalues and eigenvectors of derivative matrix, \f$\nabla_{\bf \xi}{\bf F}\f$.
+!> \brief Computes eigenvalues and eigenvectors of derivative matrix, \f$\nabla_{\bf xi}{\bf F}\f$.
 
-!> \brief Computes eigenvalues and eigenvectors of derivative matrix, \f$\nabla_{\bf \xi}{\bf F}\f$.
+!> \brief Computes eigenvalues and eigenvectors of derivative matrix, \f$\nabla_{\bf xi}{\bf F}\f$.
 !> \ingroup grp_diagnostics
 !>
 !> @param[in] NGdof number of global degrees of freedom


### PR DESCRIPTION
Numpy 2.0 breaks the binary interface to compiled code. And it is what is installed with 'pip install numpy'. Binaries compiled with numpy<2.0 cannot run with 2.0. 

Therefore we need to upgrade the repo and binaries so it is installed with numpy2.0, but leaves the system numpy intact. 

This PR does that, and is part of the numpy2.0 migration of simsopt (https://github.com/hiddenSymmetries/simsopt/issues/427) 

A speedy review would be appreciated, the changes are minor. The specific branch of f90wrap is also awaiting PR approval on upstream branch, so we might soon switch away from needing our private branch (https://github.com/jameskermode/f90wrap/pull/194). 

The edits to src/hesian.f90 are because the new f90wrap includes more meta-info in function docstrings, and LaTeX in python strings gives unexpected escape caracters. 

Will merge with two approving reviews, tests are passing. 