### PR TITLE
specify oldest numpy for python 3.8

### DIFF
--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -7,7 +7,8 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="py_spec",
     version=__version__,
-    setup_requires=["numpy>=2.0"],
+    setup_requires=["numpy>=2.0.0; python_version > '3.8'",
+                    "oldest-supported-numpy; python_version <= '3.8'"],
     install_requires=["numpy>=1.21.1"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,


### PR DESCRIPTION
fix for python 3.8 for which there is no nice combination of python packages with numpy 2.0, so just install with oldest-supported-numpy