### PR TITLE
add dependencies to setup.py, remove numpy2.0 install dep

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
     env:
       SPEC_PATH: ${{ github.workspace }}
-      PYTHONPATH: ${{ github.workspace }}/Utilities/pythontools
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
     steps:
@@ -22,6 +21,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev 
         pip3 install --user numpy f90nml scikit-build scipy h5py matplotlib
+        cd ${{ github.workspace }}/Utilities/pythontools
+        pip3 install -v .
     - name: compile_xspec
       run: |
         cd ${SPEC_PATH}
@@ -33,14 +34,12 @@ jobs:
     - name: run_fast_cartesian
       run: |
         cd ${SPEC_PATH}/ci/G1V03L2Fi
-        echo ${PYTHONPATH}
         export OMP_NUM_THREADS=1
         mpiexec -n 2 --allow-run-as-root ${SPEC_PATH}/xspec G1V03L2Fi.001.sp
         python3 -m py_spec.ci.test compare.h5 G1V03L2Fi.001.sp.h5 
     - name: run_fast_cylinder
       run: |
         cd ${SPEC_PATH}/ci/G2V32L1Fi
-        echo ${PYTHONPATH}
         export OMP_NUM_THREADS=1
         mpiexec -n 2 --allow-run-as-root ${SPEC_PATH}/xspec G2V32L1Fi.001.sp
         python3 -m py_spec.ci.test compare.h5 G2V32L1Fi.001.sp.h5 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -8,7 +8,6 @@ jobs:
       fail-fast: false
     env:
       SPEC_PATH: ${{ github.workspace }}
-      PYTHONPATH: ${{ github.workspace }}/Utilities/pythontools
       OMPI_ALLOW_RUN_AS_ROOT: 1
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
     steps:
@@ -20,6 +19,8 @@ jobs:
         pip3 install --upgrade pip
         pip3 install --user ninja cmake scipy
         pip3 install --user numpy f90nml scikit-build scipy h5py matplotlib
+        cd ${{ github.workspace }}/Utilities/pythontools
+        pip3 install -v .
     - name: Build & Test
       uses: ashutoshvarma/action-cmake-build@master
       with:
@@ -39,14 +40,12 @@ jobs:
     - name: run_fast_cartesian
       run: |
         cd ${SPEC_PATH}/ci/G1V03L2Fi
-        echo ${PYTHONPATH}
         export OMP_NUM_THREADS=1
         mpiexec -n 2 --allow-run-as-root $SPEC_PATH/install/bin/xspec G1V03L2Fi.001.sp
         python3 -m py_spec.ci.test compare.h5 G1V03L2Fi.001.sp.h5 
     - name: run_fast_cylinder
       run: |
         cd ${SPEC_PATH}/ci/G2V32L1Fi
-        echo ${PYTHONPATH}
         export OMP_NUM_THREADS=1
         mpiexec -n 2 --allow-run-as-root $SPEC_PATH/install/bin/xspec G2V32L1Fi.001.sp
         python3 -m py_spec.ci.test compare.h5 G2V32L1Fi.001.sp.h5 

--- a/.github/workflows/py_spec.yml
+++ b/.github/workflows/py_spec.yml
@@ -19,7 +19,6 @@ jobs:
       working-directory: ${{ env.PY_SPEC_DIR }}
       run: |
         pip install --upgrade pip
-        pip3 install -r requirements.txt
         pip3 install setuptools wheel twine
 
     - name: Build py_spec

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -19,7 +19,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev  libopenblas-dev cmake ninja-build
         pip install  numpy f90nml scikit-build scipy meson meson-python
-        pip install  git+https://github.com/zhucaoxiang/f90wrap@main_off
+        pip install f90wrap
 
     - name: Build python_wrapper
       run: |

--- a/Utilities/pythontools/py_spec/__init__.py
+++ b/Utilities/pythontools/py_spec/__init__.py
@@ -4,7 +4,7 @@ except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
     import importlib_metadata as metadata
 
-__version__ = metadata.version('py_spec')
+__version__ = metadata.version(__package__ or __name__)
 
 from .ci import test
 from .input.spec_namelist import SPECNamelist

--- a/Utilities/pythontools/py_spec/__init__.py
+++ b/Utilities/pythontools/py_spec/__init__.py
@@ -1,5 +1,10 @@
-# import of all SPEC-related python scripts.
-__version__ = "3.3.4"
+try:
+    from importlib import metadata
+except ImportError:
+    # Running on pre-3.8 Python; use importlib-metadata package
+    import importlib_metadata as metadata
+
+__version__ = metadata.version('py_spec')
 
 from .ci import test
 from .input.spec_namelist import SPECNamelist

--- a/Utilities/pythontools/pyproject.toml
+++ b/Utilities/pythontools/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name="py_spec"
+version="3.3.5"
+dependencies = ["numpy>=1.21.1", 
+            "f90nml",
+            "h5py", 
+            "matplotlib",
+            "coilpy; python_version<'3.12'",
+            "scipy>=1.7.0"]
+description="SPEC(Stepped-Pressure Equilibrium Code) python utilities"
+readme="README.md"
+authors = [
+    { name = "Christopher Berg Smiet", email = "christopher.smiet@epfl.ch" },
+    { name = "Caoxiang Zhu", email = "caoxiangzhu@gmail.com" },
+    { name = "SPEC developers"}
+]
+maintainers = [
+    { name = "Christopher Berg Smiet", email = "christopher.smiet@epfl.ch" },
+]
+classifiers=[
+    "Development Status :: 3 - Alpha",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering",
+]
+license = {text = "GNU 3.0"}

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -7,7 +7,6 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="py_spec",
     version=__version__,
-    setup_requires=["numpy"]
     install_requires=["numpy>=1.21.1", 
                       "coilpy",
                       "f90nml",

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -1,5 +1,6 @@
 import setuptools
 
 setuptools.setup(
+    name="py_spec"
     packages=['py_spec', 'py_spec.input', 'py_spec.output', 'py_spec.ci', 'py_spec.math']
 )

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -7,9 +7,13 @@ with open("README.md", "r") as fh:
 setuptools.setup(
     name="py_spec",
     version=__version__,
-    setup_requires=["numpy>=2.0.0; python_version > '3.8'",
-                    "oldest-supported-numpy; python_version <= '3.8'"],
-    install_requires=["numpy>=1.21.1"],
+    setup_requires=["numpy"]
+    install_requires=["numpy>=1.21.1", 
+                      "coilpy",
+                      "f90nml",
+                      "h5py", 
+                      "matplotlib"
+                      "scipy>=1.7.0"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -1,28 +1,5 @@
 import setuptools
 
-with open("README.md", "r") as fh:
-    long_description = fh.read()
-
 setuptools.setup(
-    name="py_spec",
-    version="3.3.5",
-    install_requires=["numpy>=1.21.1", 
-                      "f90nml",
-                      "h5py", 
-                      "matplotlib",
-                      "coilpy; python_version<'3.12'",
-                      "scipy>=1.7.0"],
-    description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "Programming Language :: Python :: 3",
-        "Topic :: Scientific/Engineering",
-    ],
-    url="https://princetonuniversity.github.io/SPEC/",
-    author="SPEC developers",
-    license="GNU 3.0",
     packages=['py_spec', 'py_spec.input', 'py_spec.output', 'py_spec.ci', 'py_spec.math']
 )

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
     url="https://princetonuniversity.github.io/SPEC/",
     author="SPEC developers",
     license="GNU 3.0",
-    packages=['py_spec', 'py_spec.input', 'py_spec.output', 'py_spec.ci']
+    packages=['py_spec', 'py_spec.input', 'py_spec.output', 'py_spec.ci', 'py_spec.math']
 )

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
 setuptools.setup(
-    name="py_spec"
+    name="py_spec",
     packages=['py_spec', 'py_spec.input', 'py_spec.output', 'py_spec.ci', 'py_spec.math']
 )

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -10,6 +10,7 @@ setuptools.setup(
                       "f90nml",
                       "h5py", 
                       "matplotlib",
+                      "coilpy; python_version<'3.12'",
                       "scipy>=1.7.0"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
                       "coilpy",
                       "f90nml",
                       "h5py", 
-                      "matplotlib"
+                      "matplotlib",
                       "scipy>=1.7.0"],
     description="SPEC(Stepped-Pressure Equilibrium Code) python utilities",
     long_description=long_description,

--- a/Utilities/pythontools/setup.py
+++ b/Utilities/pythontools/setup.py
@@ -1,14 +1,12 @@
 import setuptools
-from py_spec import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="py_spec",
-    version=__version__,
+    version="3.3.5",
     install_requires=["numpy>=1.21.1", 
-                      "coilpy",
                       "f90nml",
                       "h5py", 
                       "matplotlib",


### PR DESCRIPTION
The Utilities do not need python2.0 as an install dependency, as they have no binary interface. 

Also the requirements are better specified in setup.py than requirements.txt (simsopt ci manually installs requirements.txt, so leaving the file for now...). 

We should update the build system at some point, setup.py is deprecated and it is a matter of time before it fails. 

@mbkumar do you foresee any issues in simsopt CI with the removal of numpy versioning?