### PR TITLE
pp00aa dynamic OpenMP scheduling improves load imbalance

### DIFF
--- a/src/pp00aa.f90
+++ b/src/pp00aa.f90
@@ -145,7 +145,7 @@ subroutine pp00aa
       SALLOCATE( utflag, (ioff:lnPtrj                    ),    0 ) ! error flag that indicates if fieldlines successfully followed; 22 Apr 13;
       SALLOCATE(  fiota, (ioff:lnPtrj, 1:2               ), zero ) ! will always need fiota(0,1:2);
 
-!$OMP PARALLEL DO SHARED(lnPtrj,ioff,Wpp00aa,Nz,data,fiota,utflag,iota,oita,myid,vvol,cpus,Lconstraint,nPpts,ppts) PRIVATE(itrj,sti)
+!$OMP PARALLEL DO SHARED(lnPtrj,ioff,Wpp00aa,Nz,data,fiota,utflag,iota,oita,myid,vvol,cpus,Lconstraint,nPpts,ppts) PRIVATE(itrj,sti) SCHEDULE(dynamic)
       do itrj = ioff, lnPtrj ! initialize Poincare plot with trajectories regularly spaced between interfaces along \t=0;
 
         ; sti(1:2) = (/ - one + itrj    * two / lnPtrj   , Ppts*pi /)


### PR DESCRIPTION
Since poincare tracing is done using an adaptive integration routine, execution time isn't equal between points. 
Especially chaotic regions take the longer to integrate and are typically not equally distributed along the nptrj range, so this results in a significant load imbalance between threads. The default static scheduling divides the workloads in large, equal blocks between threads. Dynamic scheduling creates a more fine grained work distribution (round robin, 1 loop iteration per thread) and uses whichever threads are available at the moment.
 
This might cause a minor performance overhead in the edge case of very small `nppts`, with low  and large `nptrj`, but this should be outweighed by the improved load balance. It improved wall clock time and CPU utilization in all my tested examples. 

E.g. for a simple rotating ellipse with
```fortran
 odetol      =   1.000000000000000E-07
 nPpts       =      1000
 nPtrj       =      8    80
```
 this resulted in a speedup of 34s (1m25s to 51s) on 4 threads, and a speedup was measurable even in the "worst case" of `nppts = 1`