### PR TITLE
Fix filepath handling

### DIFF
--- a/src/dfp200.f90
+++ b/src/dfp200.f90
@@ -2110,12 +2110,12 @@ do iocons = 0, 1
             !write(ounit,1000) 'values are:' Mvol, efcol1mn(1:mn)
              !write(90,1000) efcol1mn(1:mn)
              !1000 format(" "10x" "es23.15" ")
-             !open(nm1unit, file="."//trim(ext)//".GF.hcol1", status="unknown", form="unformatted")
+             !open(nm1unit, file=hiddenext//".GF.hcol1", status="unknown", form="unformatted")
              !write(nm1unit) NGdof, Mvol
              !write(nm1unit) efcol1mn(1:Ntz)
              !close(nm1unit)
 
-             !open(nm2unit, file="."//trim(ext)//".GF.hcol2", status="unknown", form="unformatted")
+             !open(nm2unit, file=hiddenext//".GF.hcol2", status="unknown", form="unformatted")
              !!write(nm2unit) NGdof, Mvol
              !write(nm2unit) efcol2mn(1:Ntz)
              !close(nm2unit)

--- a/src/dfp200.f90
+++ b/src/dfp200.f90
@@ -2110,12 +2110,12 @@ do iocons = 0, 1
             !write(ounit,1000) 'values are:' Mvol, efcol1mn(1:mn)
              !write(90,1000) efcol1mn(1:mn)
              !1000 format(" "10x" "es23.15" ")
-             !open(nm1unit, file=trim(hidden_ext)//".GF.hcol1", status="unknown", form="unformatted")
+             !open(nm1unit, file=trim(get_hidden(ext))//".GF.hcol1", status="unknown", form="unformatted")
              !write(nm1unit) NGdof, Mvol
              !write(nm1unit) efcol1mn(1:Ntz)
              !close(nm1unit)
 
-             !open(nm2unit, file=trim(hidden_ext)//".GF.hcol2", status="unknown", form="unformatted")
+             !open(nm2unit, file=trim(get_hidden(ext))//".GF.hcol2", status="unknown", form="unformatted")
              !!write(nm2unit) NGdof, Mvol
              !write(nm2unit) efcol2mn(1:Ntz)
              !close(nm2unit)

--- a/src/dfp200.f90
+++ b/src/dfp200.f90
@@ -2110,12 +2110,12 @@ do iocons = 0, 1
             !write(ounit,1000) 'values are:' Mvol, efcol1mn(1:mn)
              !write(90,1000) efcol1mn(1:mn)
              !1000 format(" "10x" "es23.15" ")
-             !open(nm1unit, file=hiddenext//".GF.hcol1", status="unknown", form="unformatted")
+             !open(nm1unit, file=trim(hidden_ext)//".GF.hcol1", status="unknown", form="unformatted")
              !write(nm1unit) NGdof, Mvol
              !write(nm1unit) efcol1mn(1:Ntz)
              !close(nm1unit)
 
-             !open(nm2unit, file=hiddenext//".GF.hcol2", status="unknown", form="unformatted")
+             !open(nm2unit, file=trim(hidden_ext)//".GF.hcol2", status="unknown", form="unformatted")
              !!write(nm2unit) NGdof, Mvol
              !write(nm2unit) efcol2mn(1:Ntz)
              !close(nm2unit)

--- a/src/global.f90
+++ b/src/global.f90
@@ -247,7 +247,7 @@ module allglobal
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
   CHARACTER(LEN=1000)  :: ext       ! extension of input filename, i.e., "path/G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
-  CHARACTER(LEN=1000)  :: hiddenext ! ext with a "." prefix added to the basename "path/.G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
+  CHARACTER(LEN=1000)  :: hidden_ext ! ext with a "." prefix added to the basename "path/.G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
 
   REAL                 :: ForceErr !< total force-imbalance
   REAL                 :: Energy   !< MHD energy

--- a/src/global.f90
+++ b/src/global.f90
@@ -247,7 +247,6 @@ module allglobal
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
   CHARACTER(LEN=1000)  :: ext       ! extension of input filename, i.e., "path/G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
-  CHARACTER(LEN=1000)  :: hidden_ext ! ext with a "." prefix added to the basename "path/.G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
 
   REAL                 :: ForceErr !< total force-imbalance
   REAL                 :: Energy   !< MHD energy
@@ -947,6 +946,26 @@ subroutine set_mpi_comm(comm)
   if (ierr.ne.0) write(*,*) "error in call to MPI_COMM_SIZE"
 
 end subroutine
+
+!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
+
+pure function get_hidden(ext) result(hidden_ext)
+  implicit none
+  CHARACTER(len=1000), intent(in) :: ext
+  ! ext with a "." prefix added to the basename "path/.G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
+  CHARACTER(LEN=1000)  :: hidden_ext 
+  INTEGER :: basename_start_index
+
+  ! Prepare the "hidden" ext filepath that has a "." prefix.
+  ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
+#ifdef _WIN32
+    basename_start_index = INDEX(ext, '\', .TRUE.)
+#else
+    basename_start_index = INDEX(ext, '/', .TRUE.)
+#endif
+    ! folder + . + filename  
+    hidden_ext = trim(ext(1:basename_start_index))//"."//trim(ext(basename_start_index+1:))
+end function get_hidden
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 

--- a/src/global.f90
+++ b/src/global.f90
@@ -246,7 +246,8 @@ module allglobal
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
-  CHARACTER(LEN=1000)  :: ext ! extension of input filename, i.e., "G3V01L1Fi.001" for an input file G3V01L1Fi.001.sp
+  CHARACTER(LEN=1000)  :: ext       ! extension of input filename, i.e., "path/G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
+  CHARACTER(LEN=1000)  :: hiddenext ! ext with a "." prefix added to the basename "path/.G3V01L1Fi.001" for an input file path/G3V01L1Fi.001.sp
 
   REAL                 :: ForceErr !< total force-imbalance
   REAL                 :: Energy   !< MHD energy

--- a/src/hesian.f90
+++ b/src/hesian.f90
@@ -26,7 +26,7 @@ subroutine hesian( NGdof, position, Mvol, mn, LGdof )
 
   use cputiming, only : Thesian
 
-  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, &
+  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, hiddenext, &
                         im, in, &
                         iRbc, iZbs, iRbs, iZbc, &
                         dRbc, dZbs, dRbs, dZbc, &
@@ -260,7 +260,7 @@ endif
    xx(0,-2:2)= zero ; dRZ = 1.0E-04
 
    write(svol,'(i3.3)')myid
-!  open(lunit+myid,file="."//trim(ext)//".hessian."//svol,status="unknown")
+!  open(lunit+myid,file=hiddenext//".hessian."//svol,status="unknown")
 
 !  lmu(1:Nvol) = mu(1:Nvol) ; lpflux(1:Nvol) = pflux(1:Nvol) ; lhelicity(1:Nvol) = helicity(1:Nvol) ! save original profile information; 20 Jun 14;
 
@@ -402,7 +402,7 @@ endif
 !> <li> The eigenvalues and eigenvectors (if required) are written to the file \c .ext.GF.ev as follows:
 !>
 !> ```
-!> open(hunit,file="."//trim(ext)//".GF.ev",status="unknown",form="unformatted")
+!> open(hunit,file=hiddenext//".GF.ev",status="unknown",form="unformatted")
 !> write(hunit)NGdof,Ldvr,Ldvi        ! integers; if only the eigenvalues were computed then Ldvr=Ldvi=1;
 !> write(hunit)evalr(1:NGdof)         ! reals   ; real      part of eigenvalues;
 !> write(hunit)evali(1:NGdof)         ! reals   ; imaginary part of eigenvalues;
@@ -419,7 +419,7 @@ endif
   if( LHmatrix ) then
 
    if( myid.eq.0 ) then ; cput = GETTIME ; write(ounit,'("hesian : ",f10.2," : LHmatrix="L2" ;")')cput-cpus, LHmatrix ;
-    open(munit, file="."//trim(ext)//".GF.ma", status="unknown", form="unformatted")
+    open(munit, file=hiddenext//".GF.ma", status="unknown", form="unformatted")
     write(munit) NGdof
     write(munit) ohessian(1:NGdof,1:NGdof)
     close(munit)
@@ -574,7 +574,7 @@ endif
 
 
    if( myid.eq.0 ) then ! write to file; 04 Dec 14;
-    open(hunit, file="."//trim(ext)//".GF.ev", status="unknown", form="unformatted")
+    open(hunit, file=hiddenext//".GF.ev", status="unknown", form="unformatted")
     write(hunit) NGdof, Ldvr, Ldvi
     write(hunit) evalr
     write(hunit) evali

--- a/src/hesian.f90
+++ b/src/hesian.f90
@@ -26,7 +26,7 @@ subroutine hesian( NGdof, position, Mvol, mn, LGdof )
 
   use cputiming, only : Thesian
 
-  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
+  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, get_hidden, &
                         im, in, &
                         iRbc, iZbs, iRbs, iZbc, &
                         dRbc, dZbs, dRbs, dZbc, &
@@ -260,7 +260,7 @@ endif
    xx(0,-2:2)= zero ; dRZ = 1.0E-04
 
    write(svol,'(i3.3)')myid
-!  open(lunit+myid,file=trim(hidden_ext)//".hessian."//svol,status="unknown")
+!  open(lunit+myid,file=trim(get_hidden(ext))//".hessian."//svol,status="unknown")
 
 !  lmu(1:Nvol) = mu(1:Nvol) ; lpflux(1:Nvol) = pflux(1:Nvol) ; lhelicity(1:Nvol) = helicity(1:Nvol) ! save original profile information; 20 Jun 14;
 
@@ -402,7 +402,7 @@ endif
 !> <li> The eigenvalues and eigenvectors (if required) are written to the file \c .ext.GF.ev as follows:
 !>
 !> ```
-!> open(hunit,file=trim(hidden_ext)//".GF.ev",status="unknown",form="unformatted")
+!> open(hunit,file=trim(get_hidden(ext))//".GF.ev",status="unknown",form="unformatted")
 !> write(hunit)NGdof,Ldvr,Ldvi        ! integers; if only the eigenvalues were computed then Ldvr=Ldvi=1;
 !> write(hunit)evalr(1:NGdof)         ! reals   ; real      part of eigenvalues;
 !> write(hunit)evali(1:NGdof)         ! reals   ; imaginary part of eigenvalues;
@@ -419,7 +419,7 @@ endif
   if( LHmatrix ) then
 
    if( myid.eq.0 ) then ; cput = GETTIME ; write(ounit,'("hesian : ",f10.2," : LHmatrix="L2" ;")')cput-cpus, LHmatrix ;
-    open(munit, file=trim(hidden_ext)//".GF.ma", status="unknown", form="unformatted")
+    open(munit, file=trim(get_hidden(ext))//".GF.ma", status="unknown", form="unformatted")
     write(munit) NGdof
     write(munit) ohessian(1:NGdof,1:NGdof)
     close(munit)
@@ -574,7 +574,7 @@ endif
 
 
    if( myid.eq.0 ) then ! write to file; 04 Dec 14;
-    open(hunit, file=trim(hidden_ext)//".GF.ev", status="unknown", form="unformatted")
+    open(hunit, file=trim(get_hidden(ext))//".GF.ev", status="unknown", form="unformatted")
     write(hunit) NGdof, Ldvr, Ldvi
     write(hunit) evalr
     write(hunit) evali

--- a/src/hesian.f90
+++ b/src/hesian.f90
@@ -26,7 +26,7 @@ subroutine hesian( NGdof, position, Mvol, mn, LGdof )
 
   use cputiming, only : Thesian
 
-  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, hiddenext, &
+  use allglobal, only : ncpu, myid, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
                         im, in, &
                         iRbc, iZbs, iRbs, iZbc, &
                         dRbc, dZbs, dRbs, dZbc, &
@@ -260,7 +260,7 @@ endif
    xx(0,-2:2)= zero ; dRZ = 1.0E-04
 
    write(svol,'(i3.3)')myid
-!  open(lunit+myid,file=hiddenext//".hessian."//svol,status="unknown")
+!  open(lunit+myid,file=trim(hidden_ext)//".hessian."//svol,status="unknown")
 
 !  lmu(1:Nvol) = mu(1:Nvol) ; lpflux(1:Nvol) = pflux(1:Nvol) ; lhelicity(1:Nvol) = helicity(1:Nvol) ! save original profile information; 20 Jun 14;
 
@@ -402,7 +402,7 @@ endif
 !> <li> The eigenvalues and eigenvectors (if required) are written to the file \c .ext.GF.ev as follows:
 !>
 !> ```
-!> open(hunit,file=hiddenext//".GF.ev",status="unknown",form="unformatted")
+!> open(hunit,file=trim(hidden_ext)//".GF.ev",status="unknown",form="unformatted")
 !> write(hunit)NGdof,Ldvr,Ldvi        ! integers; if only the eigenvalues were computed then Ldvr=Ldvi=1;
 !> write(hunit)evalr(1:NGdof)         ! reals   ; real      part of eigenvalues;
 !> write(hunit)evali(1:NGdof)         ! reals   ; imaginary part of eigenvalues;
@@ -419,7 +419,7 @@ endif
   if( LHmatrix ) then
 
    if( myid.eq.0 ) then ; cput = GETTIME ; write(ounit,'("hesian : ",f10.2," : LHmatrix="L2" ;")')cput-cpus, LHmatrix ;
-    open(munit, file=hiddenext//".GF.ma", status="unknown", form="unformatted")
+    open(munit, file=trim(hidden_ext)//".GF.ma", status="unknown", form="unformatted")
     write(munit) NGdof
     write(munit) ohessian(1:NGdof,1:NGdof)
     close(munit)
@@ -574,7 +574,7 @@ endif
 
 
    if( myid.eq.0 ) then ! write to file; 04 Dec 14;
-    open(hunit, file=hiddenext//".GF.ev", status="unknown", form="unformatted")
+    open(hunit, file=trim(hidden_ext)//".GF.ev", status="unknown", form="unformatted")
     write(hunit) NGdof, Ldvr, Ldvi
     write(hunit) evalr
     write(hunit) evali

--- a/src/newton.f90
+++ b/src/newton.f90
@@ -329,8 +329,6 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
   ireadhessian = 0 ! set default intent out;
 
-  print *, "hiddenext = ", hiddenext
-
   select case( readorwrite )
 
   case( 'W' ) ! will write derivative matrix to file;

--- a/src/newton.f90
+++ b/src/newton.f90
@@ -64,7 +64,7 @@ subroutine newton( NGdof, position, ihybrd )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, &
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &
@@ -313,7 +313,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, hiddenext, &
+  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
                         mn, im, in, hessian, Lhessianallocated
 
   LOCALS
@@ -336,7 +336,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
    ! reset I/O state
    ios = 0
 
-   open( dunit, file=hiddenext//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
+   open( dunit, file=trim(hidden_ext)//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
    FATAL( newton, ios.ne.0, error opening derivative matrix file )
 
    write( dunit, iostat=ios ) Igeometry, Istellsym, Lfreebound, Nvol, Mpol, Ntor, NGdof ! enable resolution consistency check;
@@ -352,11 +352,11 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
    cput = GETTIME
 
-   inquire( file=hiddenext//".sp.DF", exist=exist ) ! the derivative matrix;
+   inquire( file=trim(hidden_ext)//".sp.DF", exist=exist ) ! the derivative matrix;
 
    if( exist ) then !                  01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, "reading .ext.sp.DF ;           "
-    open( dunit, file=hiddenext//".sp.DF", status="old", form="unformatted", iostat=ios )
+    open( dunit, file=trim(hidden_ext)//".sp.DF", status="old", form="unformatted", iostat=ios )
    else !                              01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, ".ext.sp.DF does not exist ;    "
     inquire( file=".sp.DF", exist=exist ) ! the derivative matrix;
@@ -442,7 +442,7 @@ subroutine fcn1( NGdof, xx, fvec, irevcm )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, &
+  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &

--- a/src/newton.f90
+++ b/src/newton.f90
@@ -64,7 +64,7 @@ subroutine newton( NGdof, position, ihybrd )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, &
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &
@@ -313,7 +313,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, &
+  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, hiddenext, &
                         mn, im, in, hessian, Lhessianallocated
 
   LOCALS
@@ -329,6 +329,8 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
   ireadhessian = 0 ! set default intent out;
 
+  print *, "hiddenext = ", hiddenext
+
   select case( readorwrite )
 
   case( 'W' ) ! will write derivative matrix to file;
@@ -336,7 +338,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
    ! reset I/O state
    ios = 0
 
-   open( dunit, file="."//trim(ext)//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
+   open( dunit, file=hiddenext//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
    FATAL( newton, ios.ne.0, error opening derivative matrix file )
 
    write( dunit, iostat=ios ) Igeometry, Istellsym, Lfreebound, Nvol, Mpol, Ntor, NGdof ! enable resolution consistency check;
@@ -352,11 +354,11 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
    cput = GETTIME
 
-   inquire( file="."//trim(ext)//".sp.DF", exist=exist ) ! the derivative matrix;
+   inquire( file=hiddenext//".sp.DF", exist=exist ) ! the derivative matrix;
 
    if( exist ) then !                  01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, "reading .ext.sp.DF ;           "
-    open( dunit, file="."//trim(ext)//".sp.DF", status="old", form="unformatted", iostat=ios )
+    open( dunit, file=hiddenext//".sp.DF", status="old", form="unformatted", iostat=ios )
    else !                              01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, ".ext.sp.DF does not exist ;    "
     inquire( file=".sp.DF", exist=exist ) ! the derivative matrix;
@@ -442,7 +444,7 @@ subroutine fcn1( NGdof, xx, fvec, irevcm )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, &
+  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &

--- a/src/newton.f90
+++ b/src/newton.f90
@@ -64,7 +64,7 @@ subroutine newton( NGdof, position, ihybrd )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, get_hidden, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &
@@ -313,7 +313,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
+  use allglobal, only : myid, cpus, MPI_COMM_SPEC, ext, get_hidden, &
                         mn, im, in, hessian, Lhessianallocated
 
   LOCALS
@@ -336,7 +336,7 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
    ! reset I/O state
    ios = 0
 
-   open( dunit, file=trim(hidden_ext)//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
+   open( dunit, file=trim(get_hidden(ext))//".sp.DF", status="replace", form="unformatted", iostat=ios ) ! save derivative matrix to file;
    FATAL( newton, ios.ne.0, error opening derivative matrix file )
 
    write( dunit, iostat=ios ) Igeometry, Istellsym, Lfreebound, Nvol, Mpol, Ntor, NGdof ! enable resolution consistency check;
@@ -352,11 +352,11 @@ subroutine writereadgf( readorwrite, NGdof , ireadhessian )
 
    cput = GETTIME
 
-   inquire( file=trim(hidden_ext)//".sp.DF", exist=exist ) ! the derivative matrix;
+   inquire( file=trim(get_hidden(ext))//".sp.DF", exist=exist ) ! the derivative matrix;
 
    if( exist ) then !                  01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, "reading .ext.sp.DF ;           "
-    open( dunit, file=trim(hidden_ext)//".sp.DF", status="old", form="unformatted", iostat=ios )
+    open( dunit, file=trim(get_hidden(ext))//".sp.DF", status="old", form="unformatted", iostat=ios )
    else !                              01234567890123456789012345678901
     write(ounit,2000) cput-cpus, myid, ".ext.sp.DF does not exist ;    "
     inquire( file=".sp.DF", exist=exist ) ! the derivative matrix;
@@ -442,7 +442,7 @@ subroutine fcn1( NGdof, xx, fvec, irevcm )
 
   use cputiming, only : Tnewton
 
-  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, &
+  use allglobal, only : wrtend, myid, ncpu, cpus, MPI_COMM_SPEC, ext, get_hidden, &
                         NOTstellsym, &
                         ForceErr, Energy, &
                         mn, im, in, iRbc, iZbs, iRbs, iZbc, Mvol, &

--- a/src/pp00aa.f90
+++ b/src/pp00aa.f90
@@ -25,7 +25,7 @@
 !>
 !>~~~~~~~~~~~~
 !> write(svol,'(i4.4)')lvol ! lvol labels volume;
-!> open(lunit+myid,file=hiddenext//".poincare."//svol,status="unknown",form="unformatted")
+!> open(lunit+myid,file=trim(hidden_ext)//".poincare."//svol,status="unknown",form="unformatted")
 !> do until end of file
 !>   write(lunit+myid) Nz, nPpts                ! integers
 !>   write(lunit+myid) data(1:4,0:Nz-1,1:nPpts) ! doubles
@@ -55,7 +55,7 @@
 !> <li> The rotational-transform data is written to \c .ext.transform:xxxx , where \c xxxx is an integer indicating the volume.
 !>       The format of this file is as follows:
 !> ```
-!>  open(lunit+myid,file=hiddenext//".sp.t."//svol,status="unknown",form="unformatted")
+!>  open(lunit+myid,file=trim(hidden_ext)//".sp.t."//svol,status="unknown",form="unformatted")
 !>  write(lunit+myid) lnPtrj-ioff+1                                      ! integer
 !>  write(lunit+myid) diotadxup(0:1,0,lvol)                              ! doubles
 !>  write(lunit+myid) ( fiota(itrj,1:2), itrj = ioff, lnPtrj ) ! doubles

--- a/src/pp00aa.f90
+++ b/src/pp00aa.f90
@@ -25,7 +25,7 @@
 !>
 !>~~~~~~~~~~~~
 !> write(svol,'(i4.4)')lvol ! lvol labels volume;
-!> open(lunit+myid,file="."//trim(ext)//".poincare."//svol,status="unknown",form="unformatted")
+!> open(lunit+myid,file=hiddenext//".poincare."//svol,status="unknown",form="unformatted")
 !> do until end of file
 !>   write(lunit+myid) Nz, nPpts                ! integers
 !>   write(lunit+myid) data(1:4,0:Nz-1,1:nPpts) ! doubles
@@ -55,7 +55,7 @@
 !> <li> The rotational-transform data is written to \c .ext.transform:xxxx , where \c xxxx is an integer indicating the volume.
 !>       The format of this file is as follows:
 !> ```
-!>  open(lunit+myid,file="."//trim(ext)//".sp.t."//svol,status="unknown",form="unformatted")
+!>  open(lunit+myid,file=hiddenext//".sp.t."//svol,status="unknown",form="unformatted")
 !>  write(lunit+myid) lnPtrj-ioff+1                                      ! integer
 !>  write(lunit+myid) diotadxup(0:1,0,lvol)                              ! doubles
 !>  write(lunit+myid) ( fiota(itrj,1:2), itrj = ioff, lnPtrj ) ! doubles

--- a/src/pp00aa.f90
+++ b/src/pp00aa.f90
@@ -25,7 +25,7 @@
 !>
 !>~~~~~~~~~~~~
 !> write(svol,'(i4.4)')lvol ! lvol labels volume;
-!> open(lunit+myid,file=trim(hidden_ext)//".poincare."//svol,status="unknown",form="unformatted")
+!> open(lunit+myid,file=trim(get_hidden(ext))//".poincare."//svol,status="unknown",form="unformatted")
 !> do until end of file
 !>   write(lunit+myid) Nz, nPpts                ! integers
 !>   write(lunit+myid) data(1:4,0:Nz-1,1:nPpts) ! doubles
@@ -55,7 +55,7 @@
 !> <li> The rotational-transform data is written to \c .ext.transform:xxxx , where \c xxxx is an integer indicating the volume.
 !>       The format of this file is as follows:
 !> ```
-!>  open(lunit+myid,file=trim(hidden_ext)//".sp.t."//svol,status="unknown",form="unformatted")
+!>  open(lunit+myid,file=trim(get_hidden(ext))//".sp.t."//svol,status="unknown",form="unformatted")
 !>  write(lunit+myid) lnPtrj-ioff+1                                      ! integer
 !>  write(lunit+myid) diotadxup(0:1,0,lvol)                              ! doubles
 !>  write(lunit+myid) ( fiota(itrj,1:2), itrj = ioff, lnPtrj ) ! doubles

--- a/src/ra00aa.f90
+++ b/src/ra00aa.f90
@@ -24,7 +24,7 @@
 !> <ul>
 !> <li> The format of the files containing the vector potential is as follows:
 !> ```
-!> open(aunit, file=hiddenext//".sp.A", status="replace", form="unformatted" )
+!> open(aunit, file=trim(hidden_ext)//".sp.A", status="replace", form="unformatted" )
 !> write(aunit) Mvol, Mpol, Ntor, mn, Nfp ! integers;
 !> write(aunit) im(1:mn) ! integers; poloidal modes;
 !> write(aunit) in(1:mn) ! integers; toroidal modes;
@@ -57,7 +57,7 @@ subroutine ra00aa( writeorread )
 
   use cputiming, only : Tra00aa
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, Mvol, mn, im, in, Ate, Aze, Ato, Azo
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, Mvol, mn, im, in, Ate, Aze, Ato, Azo
 
   use sphdf5,    only : write_vector_potential
 
@@ -148,12 +148,12 @@ subroutine ra00aa( writeorread )
 
    if( myid.eq.0 ) then
 
-    inquire(file=hiddenext//".sp.A",exist=exist)
+    inquire(file=trim(hidden_ext)//".sp.A",exist=exist)
 
     if( .not.exist ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; .ext.sp.A does not exist ;")') cput-cpus, myid ; goto 9998
     endif
 
-    open(aunit,file=hiddenext//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
+    open(aunit,file=trim(hidden_ext)//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
 
     if( ios.ne.0 ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; opening .ext.sp.A ;")') cput-cpus, myid ; goto 9997
     endif

--- a/src/ra00aa.f90
+++ b/src/ra00aa.f90
@@ -24,7 +24,7 @@
 !> <ul>
 !> <li> The format of the files containing the vector potential is as follows:
 !> ```
-!> open(aunit, file=trim(hidden_ext)//".sp.A", status="replace", form="unformatted" )
+!> open(aunit, file=trim(get_hidden(ext))//".sp.A", status="replace", form="unformatted" )
 !> write(aunit) Mvol, Mpol, Ntor, mn, Nfp ! integers;
 !> write(aunit) im(1:mn) ! integers; poloidal modes;
 !> write(aunit) in(1:mn) ! integers; toroidal modes;
@@ -57,7 +57,7 @@ subroutine ra00aa( writeorread )
 
   use cputiming, only : Tra00aa
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hidden_ext, Mvol, mn, im, in, Ate, Aze, Ato, Azo
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, get_hidden, Mvol, mn, im, in, Ate, Aze, Ato, Azo
 
   use sphdf5,    only : write_vector_potential
 
@@ -148,12 +148,12 @@ subroutine ra00aa( writeorread )
 
    if( myid.eq.0 ) then
 
-    inquire(file=trim(hidden_ext)//".sp.A",exist=exist)
+    inquire(file=trim(get_hidden(ext))//".sp.A",exist=exist)
 
     if( .not.exist ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; .ext.sp.A does not exist ;")') cput-cpus, myid ; goto 9998
     endif
 
-    open(aunit,file=trim(hidden_ext)//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
+    open(aunit,file=trim(get_hidden(ext))//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
 
     if( ios.ne.0 ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; opening .ext.sp.A ;")') cput-cpus, myid ; goto 9997
     endif

--- a/src/ra00aa.f90
+++ b/src/ra00aa.f90
@@ -24,7 +24,7 @@
 !> <ul>
 !> <li> The format of the files containing the vector potential is as follows:
 !> ```
-!> open(aunit, file="."//trim(ext)//".sp.A", status="replace", form="unformatted" )
+!> open(aunit, file=hiddenext//".sp.A", status="replace", form="unformatted" )
 !> write(aunit) Mvol, Mpol, Ntor, mn, Nfp ! integers;
 !> write(aunit) im(1:mn) ! integers; poloidal modes;
 !> write(aunit) in(1:mn) ! integers; toroidal modes;
@@ -57,7 +57,7 @@ subroutine ra00aa( writeorread )
 
   use cputiming, only : Tra00aa
 
-  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, Mvol, mn, im, in, Ate, Aze, Ato, Azo
+  use allglobal, only : myid, ncpu, cpus, MPI_COMM_SPEC, ext, hiddenext, Mvol, mn, im, in, Ate, Aze, Ato, Azo
 
   use sphdf5,    only : write_vector_potential
 
@@ -148,12 +148,12 @@ subroutine ra00aa( writeorread )
 
    if( myid.eq.0 ) then
 
-    inquire(file="."//trim(ext)//".sp.A",exist=exist)
+    inquire(file=hiddenext//".sp.A",exist=exist)
 
     if( .not.exist ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; .ext.sp.A does not exist ;")') cput-cpus, myid ; goto 9998
     endif
 
-    open(aunit,file="."//trim(ext)//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
+    open(aunit,file=hiddenext//".sp.A",status="old",form="unformatted",iostat=ios) ! this will contain initial guess for vector potential;
 
     if( ios.ne.0 ) then ; write(ounit,'("ra00aa : ",f10.2," : myid=",i3," ; error ; opening .ext.sp.A ;")') cput-cpus, myid ; goto 9997
     endif

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -204,12 +204,12 @@ subroutine read_command_args
 
   use fileunits, only: ounit
   use inputlist, only: Wreadin
-  use allglobal, only: cpus, myid, ext, hiddenext, MPI_COMM_SPEC, write_spec_namelist
+  use allglobal, only: cpus, myid, ext, hidden_ext, MPI_COMM_SPEC, write_spec_namelist
 
   LOCALS
 
   LOGICAL              :: Lspexist
-  INTEGER              :: iargc, iarg, numargs, extlen, sppos, basenamestart
+  INTEGER              :: iargc, iarg, numargs, extlen, sppos, basename_start_index
 
   CHARACTER(len=100)   :: arg
 
@@ -246,12 +246,12 @@ subroutine read_command_args
         ! Prepare the "hidden" ext filepath that has a "." prefix.
         ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
 #ifdef _WIN32
-          basenamestart = INDEX(ext, '\', .TRUE.)
+          basename_start_index = INDEX(ext, '\', .TRUE.)
 #else
-          basenamestart = INDEX(ext, '/', .TRUE.)
+          basename_start_index = INDEX(ext, '/', .TRUE.)
 #endif
         ! folder + . + filename  
-        hiddenext = trim(ext(1:basenamestart))//"."//trim(ext(basenamestart+1:))
+        hidden_ext = trim(ext(1:basename_start_index))//"."//trim(ext(basename_start_index+1:))
 
         write(ounit,'("rdcmdl : ", 10x ," : ")')
         write(ounit,'("rdcmdl : ",f10.2," : ext = ",a100)') cput-cpus, ext

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -204,12 +204,12 @@ subroutine read_command_args
 
   use fileunits, only: ounit
   use inputlist, only: Wreadin
-  use allglobal, only: cpus, myid, ext, MPI_COMM_SPEC, write_spec_namelist
+  use allglobal, only: cpus, myid, ext, hiddenext, MPI_COMM_SPEC, write_spec_namelist
 
   LOCALS
 
   LOGICAL              :: Lspexist
-  INTEGER              :: iargc, iarg, numargs, extlen, sppos
+  INTEGER              :: iargc, iarg, numargs, extlen, sppos, basenamestart
 
   CHARACTER(len=100)   :: arg
 
@@ -242,6 +242,11 @@ subroutine read_command_args
             arg = arg(1:extlen-3)         ! if this is the case, remove ".sp" from end of ext
         endif
         ext = trim(arg)
+
+        ! Prepare the "hidden" ext filepath that has a "." prefix.
+        ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
+        basenamestart = INDEX(ext, '/', .TRUE.)
+        hiddenext = trim(ext(1:basenamestart))//"."//trim(ext(basenamestart+1:))
 
         write(ounit,'("rdcmdl : ", 10x ," : ")')
         write(ounit,'("rdcmdl : ",f10.2," : ext = ",a100)') cput-cpus, ext

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -245,11 +245,11 @@ subroutine read_command_args
 
         ! Prepare the "hidden" ext filepath that has a "." prefix.
         ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
-        #ifdef _WIN32
+#ifdef _WIN32
           basenamestart = INDEX(ext, '\', .TRUE.)
-        #else
+#else
           basenamestart = INDEX(ext, '/', .TRUE.)
-        #endif
+#endif
         ! folder + . + filename  
         hiddenext = trim(ext(1:basenamestart))//"."//trim(ext(basenamestart+1:))
 

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -245,7 +245,12 @@ subroutine read_command_args
 
         ! Prepare the "hidden" ext filepath that has a "." prefix.
         ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
-        basenamestart = INDEX(ext, '/', .TRUE.)
+        #ifdef _WIN32
+          basenamestart = INDEX(ext, '\', .TRUE.)
+        #else
+          basenamestart = INDEX(ext, '/', .TRUE.)
+        #endif
+        ! folder + . + filename  
         hiddenext = trim(ext(1:basenamestart))//"."//trim(ext(basenamestart+1:))
 
         write(ounit,'("rdcmdl : ", 10x ," : ")')

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -204,12 +204,12 @@ subroutine read_command_args
 
   use fileunits, only: ounit
   use inputlist, only: Wreadin
-  use allglobal, only: cpus, myid, ext, hidden_ext, MPI_COMM_SPEC, write_spec_namelist
+  use allglobal, only: cpus, myid, ext, get_hidden, MPI_COMM_SPEC, write_spec_namelist
 
   LOCALS
 
   LOGICAL              :: Lspexist
-  INTEGER              :: iargc, iarg, numargs, extlen, sppos, basename_start_index
+  INTEGER              :: iargc, iarg, numargs, extlen, sppos
 
   CHARACTER(len=100)   :: arg
 
@@ -242,16 +242,6 @@ subroutine read_command_args
             arg = arg(1:extlen-3)         ! if this is the case, remove ".sp" from end of ext
         endif
         ext = trim(arg)
-
-        ! Prepare the "hidden" ext filepath that has a "." prefix.
-        ! Split ext into directory path and basename using INDEX function, then concatenate them again with a "." inbetween
-#ifdef _WIN32
-          basename_start_index = INDEX(ext, '\', .TRUE.)
-#else
-          basename_start_index = INDEX(ext, '/', .TRUE.)
-#endif
-        ! folder + . + filename  
-        hidden_ext = trim(ext(1:basename_start_index))//"."//trim(ext(basename_start_index+1:))
 
         write(ounit,'("rdcmdl : ", 10x ," : ")')
         write(ounit,'("rdcmdl : ",f10.2," : ext = ",a100)') cput-cpus, ext


### PR DESCRIPTION
Solves issue https://github.com/PrincetonUniversity/SPEC/issues/206 related to running SPEC from a different working directory than the input file.

Currently writes both output files and hidden files to the same directory as the input file. 

The most interesting change is in the first commit, where we define the filepaths for the output files `ext` and the filepath for the hidden files `hiddenext` (derivative, hessian, ...)