### PR TITLE
py_spec minor bugfix

### DIFF
--- a/Utilities/pythontools/py_spec/output/_plot_iota.py
+++ b/Utilities/pythontools/py_spec/output/_plot_iota.py
@@ -16,10 +16,10 @@ def plot_iota(self, xaxis="R", yaxis="i", ax=None, **kwargs):
     plt.sca(ax)
     # set default plotting parameters
     # use dots
-    if kwargs.get("marker") == None:
+    if "marker" not in kwargs:
         kwargs.update({"marker": "*"})
     # use gray color
-    if kwargs.get("c") == None:
+    if "c" not in kwargs:
         pass
         # kwargs.update({"c": "gray"})
 

--- a/Utilities/pythontools/py_spec/output/_plot_kam_surface.py
+++ b/Utilities/pythontools/py_spec/output/_plot_kam_surface.py
@@ -28,9 +28,9 @@ def plot_kam_surface(self, ns=[], ntheta=1000, zeta=0.0, ax=None, **kwargs):
         fig, ax = plt.subplots()
     plt.sca(ax)
     # set default plotting parameters
-    if kwargs.get("label") == None:
+    if "label" not in kwargs:
         kwargs.update({"label": "SPEC_KAM"})  # default label
-    if kwargs.get("c") == None:
+    if "c" not in kwargs:
         kwargs.update({"c": "red"})
     # plot all the surfaces
     if Igeometry == 3:

--- a/Utilities/pythontools/py_spec/output/_plot_modB.py
+++ b/Utilities/pythontools/py_spec/output/_plot_modB.py
@@ -23,7 +23,7 @@ def plot_modB(
     import matplotlib.pyplot as plt
 
     Nvol = self.input.physics.Nvol
-    if lvol == None:
+    if lvol is None:
         lvollist = np.arange(0, Nvol, dtype=int).tolist()
     elif np.isscalar(lvol):
         lvollist = [lvol]

--- a/Utilities/pythontools/py_spec/output/_plot_poincare.py
+++ b/Utilities/pythontools/py_spec/output/_plot_poincare.py
@@ -31,19 +31,24 @@ def plot_poincare(self, toroidalIdx=0, prange="full", ax=None, **kwargs):
         zz = self.poincare.R[:, :, toroidalIdx] * np.sin(
             self.poincare.t[:, :, toroidalIdx]
         )
+
+    # Replace invalid values (unsuccessful tracing) with nan for plotting 
+    zz[(self.poincare.success[:,np.newaxis]!=1) | ((rr==0) & (zz==0))] = np.nan 
+    rr[(self.poincare.success[:,np.newaxis]!=1) | ((rr==0) & (zz==0))] = np.nan
+    
     # get axix data
     if ax is None:
         fig, ax = plt.subplots()
     plt.sca(ax)
     # set default plotting parameters
     # use dots
-    if kwargs.get("marker") == None:
+    if "marker" not in kwargs:
         kwargs.update({"marker": "."})
     # use gray color
-    if kwargs.get("c") == None:
+    if "c" not in kwargs:
         pass
     # size of marker
-    if kwargs.get("s") == None:
+    if "s" not in kwargs:
         kwargs.update({"s": 0.3})
         # kwargs.update({"c": "gray"})
     # make plot depending on the 'range'

--- a/Utilities/pythontools/py_spec/output/_plot_pressure.py
+++ b/Utilities/pythontools/py_spec/output/_plot_pressure.py
@@ -19,9 +19,9 @@ def plot_pressure(self, normalize=True, ax=None, **kwargs):
         fig, ax = plt.subplots()
     plt.sca(ax)
     # set default plotting parameters
-    if kwargs.get("linewidth") == None:
+    if "linewidth" not in kwargs:
         kwargs.update({"linewidth": 2.0})  # prefer thicker lines
-    if kwargs.get("label") == None:
+    if "label" not in kwargs:
         kwargs.update({"label": "self_pressure"})  # default label
     # process data
     _tflux = np.insert(tflux, 0, 0)

--- a/Utilities/pythontools/py_spec/output/spec.py
+++ b/Utilities/pythontools/py_spec/output/spec.py
@@ -55,7 +55,7 @@ class SPECout:
         # as self.`args[0]`
 
         _content = None
-        if kwargs.get("content") == None:
+        if "content" not in kwargs:
             # assume arg[0] is a filename
             _content = h5py.File(args[0], "r")
 


### PR DESCRIPTION
`None` checks should be done with is None in python, instead of `== None` to avoid issues with equality overloads.
Passing an RGB color (np.array) to to the plotting functions threw at the None comparison, because numpy arrays need `.any()` or `.all()` for comparisons. I also refactored other instances of the same bug across the codebase.

plot_poincare now also ignores points that were unsuccessfully integrated instead of plotting them at [0,0]  