### PR TITLE
remove deprecated findFFTW that fails on runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev 
+        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev 
         pip3 install --user numpy f90nml scikit-build scipy h5py matplotlib
         cd ${{ github.workspace }}/Utilities/pythontools
         pip3 install -v .

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install prereqs
       run: |
         sudo apt-get update
-        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-103 libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev 
+        sudo apt-get install gfortran mpi-default-bin mpi-default-dev libhdf5-dev libfftw3-bin libfftw3-dev libopenblas0-openmp libopenblas-dev 
         pip3 install --upgrade pip
         pip3 install --user ninja cmake scipy
         pip3 install --user numpy f90nml scikit-build scipy h5py matplotlib

--- a/.github/workflows/python_wrapper.yml
+++ b/.github/workflows/python_wrapper.yml
@@ -8,6 +8,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
     # Python3 should be pre-installed on 'ubuntu-latest'
     - name: Python version info
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,36 +80,45 @@ find_package (LAPACK REQUIRED)
 # Find FFTW3.
 # Intel oneAPI has FFT3 available as part of MKL. Just linking against MKL gives FFTW functionality.
 if (NOT ${BLA_VENDOR} MATCHES "^Intel")
-    # For standard FFTW library
-    # We are using findfftw module from github/egpbos. 
-    # PPPL provides fftwconfig.cmake. We could try that first in future
+  find_package(FFTW3 REQUIRED)
 
-    # To guide cmake to the location of FFT, set FFTW_ROOT to the path of FFTW
-    # Ex: For PPPL gcc suite of compilers, 
-    # We are using FFTW find module from github.com/egpbos
-    # 
-    configure_file(downloadFindFFTW.cmake.in findFFTW-download/CMakeLists.txt)
-    execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-download )
-    if(result)
-        message(FATAL_ERROR "CMake step for findFFTW failed: ${result}")
-    else()
-        message("CMake step for findFFTW completed (${result}).")
-    endif()
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-        RESULT_VARIABLE result
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-download )
-    if(result)
-        message(FATAL_ERROR "Build step for findFFTW failed: ${result}")
-    endif()
+  # will find it, but FFTW_LIBRARIES is set to 'fftw3' simple string, which F2py does not like
+  
+  # Hack to find the proper .so looking first in conda, then in other 
+  set(FFTW3_LIBRARY_PATHS) # Initialize empty list
 
-    set(findFFTW_DIR ${CMAKE_CURRENT_BINARY_DIR}/findFFTW-src)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${findFFTW_DIR}")
+  if(DEFINED CONDA_PREFIX)
+    list(APPEND FFTW3_LIBRARY_PATHS "${CONDA_PREFIX}/lib") # Add Conda first
+  endif()
 
-    find_package(FFTW REQUIRED)
+  list(APPEND FFTW3_LIBRARY_PATHS
+    /usr/lib
+    /usr/local/lib
+    ${FFTW3_ROOT_DIR}/lib
+  )
+  # also add a path relative to the found include dirs, which is a true path
+  if(FFTW3_INCLUDE_DIRS)
+    string(REPLACE "/include" "/lib" FFTW3_LIBRARY_DIR_FROM_INCLUDE "${FFTW3_INCLUDE_DIRS}")
+    list(APPEND FFTW3_LIBRARY_PATHS ${FFTW3_LIBRARY_DIR_FROM_INCLUDE})
+  endif()
+
+  # Find the library using the constructed list of paths. Should find the path to the .so
+  find_library(FFTW3_LIBRARY_TRUE
+    NAMES fftw3
+    PATHS ${FFTW3_LIBRARY_PATHS}
+    NO_DEFAULT_PATH
+  )
+
+  if(FFTW3_LIBRARY_TRUE)
+    message(STATUS "FFTW3 Library with full path found: ${FFTW3_LIBRARY_TRUE}")
+    set(FFTW3_FULL_PATH ${FFTW3_LIBRARY})
+  else()
+    message(FATAL_ERROR "Could not find FFTW3 library with find_library.")
+  endif()
+
+
 else()   # Not required for OneAPI, but for older  versions
-    set(FFTW_INCLUDE_DIRS $ENV{MKLROOT}/include/fftw)
+    set(FFTW3_INCLUDE_DIRS $ENV{MKLROOT}/include/fftw)
 endif()
 
 # Find HDF5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,41 +80,45 @@ find_package (LAPACK REQUIRED)
 # Find FFTW3.
 # Intel oneAPI has FFT3 available as part of MKL. Just linking against MKL gives FFTW functionality.
 if (NOT ${BLA_VENDOR} MATCHES "^Intel")
-  find_package(FFTW3 REQUIRED)
-
-  # will find it, but FFTW_LIBRARIES is set to 'fftw3' simple string, which F2py does not like
-  
   # Hack to find the proper .so looking first in conda, then in other 
-  set(FFTW3_LIBRARY_PATHS) # Initialize empty list
+  set(FFTW3_TEST_PATHS) # Initialize empty list
 
   if(DEFINED CONDA_PREFIX)
-    list(APPEND FFTW3_LIBRARY_PATHS "${CONDA_PREFIX}/lib") # Add Conda first
+    list(APPEND FFTW3_TEST_PATHS "${CONDA_PREFIX}/lib") # Add Conda first
   endif()
 
-  list(APPEND FFTW3_LIBRARY_PATHS
+  list(APPEND FFTW3_TEST_PATHS
     /usr/lib
     /usr/local/lib
     ${FFTW3_ROOT_DIR}/lib
   )
-  # also add a path relative to the found include dirs, which is a true path
-  if(FFTW3_INCLUDE_DIRS)
-    string(REPLACE "/include" "/lib" FFTW3_LIBRARY_DIR_FROM_INCLUDE "${FFTW3_INCLUDE_DIRS}")
-    list(APPEND FFTW3_LIBRARY_PATHS ${FFTW3_LIBRARY_DIR_FROM_INCLUDE})
-  endif()
 
   # Find the library using the constructed list of paths. Should find the path to the .so
   find_library(FFTW3_LIBRARY_TRUE
     NAMES fftw3
-    PATHS ${FFTW3_LIBRARY_PATHS}
-    NO_DEFAULT_PATH
+    PATHS ${FFTW3_TEST_PATHS}
   )
 
-  if(FFTW3_LIBRARY_TRUE)
-    message(STATUS "FFTW3 Library with full path found: ${FFTW3_LIBRARY_TRUE}")
-    set(FFTW3_FULL_PATH ${FFTW3_LIBRARY})
-  else()
-    message(FATAL_ERROR "Could not find FFTW3 library with find_library.")
+
+  set(FFTW_INC_TEST_PATHS) # Initialize an empty list for include paths
+
+  foreach(path ${FFTW3_TEST_PATHS})
+    string(REGEX REPLACE "/lib$" "/include" INCLUDE_PATH "${path}")
+    list(APPEND FFTW_INC_TEST_PATHS "${INCLUDE_PATH}")
+  endforeach()
+
+  find_path(FFTW3_INCLUDE_DIRS # Use FFTW3_INCLUDE_DIRS as in the normal find_package call.
+    NAMES fftw3.f90 fftw3.h # Check for both Fortran and C headers
+    PATHS ${FFTW_INC_TEST_PATHS}
+    REQUIRED
+  )
+
+  if(NOT FFTW3_LIBRARY_TRUE)
+      message(FATAL_ERROR "Could not find FFTW3 library with find_library.")
   endif()
+
+  message(STATUS "found fftw3 library with path: ${FFTW3_LIBRARY_TRUE}")
+  message(STATUS "found fftw3 include dir with path: ${FFTW3_INCLUDE_DIRS}")
 
 
 else()   # Not required for OneAPI, but for older  versions

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -262,11 +262,11 @@ target_include_directories(spec PUBLIC ${HDF5_C_INCLUDE_DIRS} ${HDF5_Fortran_INC
 # MKL could be used for all the three
 target_link_libraries(spec 
     PUBLIC 
-        ${FFTW_LIBRARIES} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
+    ${FFTW3_LIBRARY_TRUE} ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
 )
 target_include_directories(spec 
     PUBLIC 
-        ${FFTW_INCLUDE_DIRS} ${LAPACK_INCLUDE_DIRS} ${BLAS_INCLUDE_DIRS}
+        ${FFTW3_INCLUDE_DIRS} ${LAPACK_INCLUDE_DIRS} ${BLAS_INCLUDE_DIRS}
 )
 
 #if(SKBUILD)


### PR DESCRIPTION
the findFFTW hack has run its course, modern CMake is reasonably good at finding it, and the repo has not been updated in 4 years. 

This is now causing simsopt CI to fail as findFFTW has a `cmake_minimum_required(VERSION 3.5.0)` somewere, and newest runners with modern CMakes refuse to continue when they see that. 

Instead of patching this old workaround, and stack the hacks, I modified it to use normal CMake. 

Because F2py is picky, I had to add a few extra hoops to resolve the full library path and name. 