### PR TITLE
No axis derivatives in hessian calculation

### DIFF
--- a/src/global.f90
+++ b/src/global.f90
@@ -743,6 +743,7 @@ module allglobal
   REAL,    allocatable :: dessian3D(:,:) !< derivative Hessian 3D
 
   REAL,    allocatable :: force_final(:) !< Final force on the interfaces [inface*mode]
+  REAL,    allocatable :: force_final_grad(:, :) !< Final force gradient on the interfaces
 !> @}
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!

--- a/src/hesian.f90
+++ b/src/hesian.f90
@@ -35,7 +35,7 @@ subroutine hesian( NGdof, position, Mvol, mn, LGdof )
                         dFFdRZ,HdFFdRZ, dBBdmp, dmupfdx, hessian, dessian, Lhessianallocated, psifactor, &
                         hessian2D,dessian2D,Lhessian2Dallocated, &
                         Lhessian3Dallocated,denergydrr, denergydrz,denergydzr,denergydzz, &
-					            	LocalConstraint
+					            	LocalConstraint, dRodR, dRodZ, dZodR, dZodZ, dRadR, dRadZ, dZadR, dZadZ
   
   use sphdf5, only : write_stability
 
@@ -240,6 +240,15 @@ endif
    Lhessianallocated = .true.
   !endif
    !This step cleared.
+
+  dRodR = 0.0
+  dZodR = 0.0
+  dRodZ = 0.0
+  dZodZ = 0.0
+  dRadR = 0.0
+  dRadZ = 0.0
+  dZadR = 0.0
+  dZadZ = 0.0
 
   LComputeDerivatives = .true. !; position(0) = zero ! this is not used; 11 Aug 14;
   LComputeAxis = .false.

--- a/src/sphdf5.f90
+++ b/src/sphdf5.f90
@@ -1042,7 +1042,7 @@ subroutine hdfint
                         TT, &
                         beltramierror, &
                         IPDt, dlambdaout, lmns, &
-                        force_final, hessian, NGdof
+                        force_final, force_final_grad, NGdof
 
   LOCALS
 
@@ -1171,7 +1171,7 @@ subroutine hdfint
 
   if( Lcheck.eq.7 ) then
     HWRITERV(grpOutput, NGdof+1, force_final, force_final(0:NGdof))
-    HWRITERA( grpOutput, NGdof, NGdof, force_final_grad, hessian(1:NGdof,1:NGdof) )
+    HWRITERA( grpOutput, NGdof, NGdof, force_final_grad, force_final_grad(1:NGdof,1:NGdof) )
   end if
 
   HCLOSEGRP( grpOutput )

--- a/src/xspech.f90
+++ b/src/xspech.f90
@@ -319,7 +319,7 @@ subroutine spec
                         version, &
                         MPI_COMM_SPEC, &
                         force_final, Lhessianallocated, LocalConstraint, hessian, dBBdmp, dFFdRZ, dmupfdx, &
-                        dRodR, dRodZ, dZodR, dZodZ, dRadR, dRadZ, dZadR, dZadZ, dessian, LGdof
+                        dRodR, dRodZ, dZodR, dZodZ, dRadR, dRadZ, dZadR, dZadZ, dessian, LGdof, force_final_grad
 
 !-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!-!
 
@@ -514,6 +514,10 @@ subroutine spec
     WCALL( xspech, dforce, ( NGdof, position(0:NGdof), force_final(0:NGdof), LComputeDerivatives, LComputeAxis) )
     Lfindzero = Lfindzero_temp
 
+    ! Save force gradient for output to .h5 file
+    SALLOCATE( force_final_grad, (1:NGdof,1:NGdof), zero ) 
+    force_final_grad(1:NGdof,1:NGdof) = hessian(1:NGdof,1:NGdof)
+    
   else
     SALLOCATE( force_final, (0:NGdof), zero )
 


### PR DESCRIPTION
When calculating the hessian (2nd variation of energy), the axis displacement is not to be accounted for. However, currently, previous calculation of axis derivatives for purposes of finding the force gradient would make the hessian also dependent on the axis. This removes the dependency.